### PR TITLE
chore(providers): shortcut for configuring DEFAULT_FIREBASE provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 dist/
 typings/
-
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -22,6 +22,24 @@ import {FIREBASE_PROVIDERS} from 'angularfire2';
 bootstrap(App, FIREBASE_PROVIDERS);
 ```
 
+### defaultFirebase
+
+Define the root url for the library, to resolve relative paths.
+
+Type: `string`
+
+Usage:
+
+```
+import {bootstrap} from 'angular2/core';
+import {FIREBASE_PROVIDERS, defaultFirebase} from 'angularfire2';
+
+bootstrap(App, [
+  FIREBASE_PROVIDERS,
+  defaultFirebase('https://my.firebaseio.com')
+]);
+```
+
 ### FirebaseRef
 
 Injectable symbol to create a Firebase reference based on
@@ -40,27 +58,6 @@ class MyComponent {
     ref.on('value', this.doSomething);
   }
 }
-```
-
-### FirebaseUrl
-
-URL for the app's default Firebase database.
-
-Type: `string`
-
-Usage:
-
-```
-import {App} from './app';
-import {bootstrap, provide} from 'angular2/core';
-import {FirebaseUrl, FIREBASE_PROVIDERS} from 'angularfire2';
-
-bootstrap(App, [
-  FIREBASE_PROVIDERS,
-  provide(FirebaseUrl, {
-    useValue: 'https://my.firebaseio.com'
-  })
-]);
 ```
 
 ### FirebaseList
@@ -104,6 +101,32 @@ class QuestionsList {
     @Inject('/topics') public topics:FirebaseObservable<any>) {
   }
 }
+```
+
+### FirebaseUrl
+
+URL for the app's default Firebase database.
+
+Type: `string`
+
+Usage:
+
+```
+import {bootstrap, Inject} from 'angular2/core';
+import {FirebaseUrl, FIREBASE_PROVIDERS, defaultFirebase} from 'angularfire2';
+
+@Component({
+  selector: 'app',
+  template: `<a [href]="url">{{ url }}</a>`
+})
+class App {
+  constructor(@Inject(FirebaseUrl) public url: string) {}
+}
+
+bootstrap(App, [
+  FIREBASE_PROVIDERS,
+  defaultFirebase('https://my.firebaseio.com')
+]);
 ```
 
 ### FirebaseListConfig

--- a/src/angularfire.spec.ts
+++ b/src/angularfire.spec.ts
@@ -1,8 +1,8 @@
-import {describe,it,beforeEach, expect} from 'angular2/testing';
+import {describe,it,beforeEach, expect, inject} from 'angular2/testing';
 import {Injector, provide, Provider} from 'angular2/core';
 import {FIREBASE_PROVIDERS, FirebaseUrl, FirebaseRef, defaultFirebase} from './angularfire';
 
-const testUrl = 'https://ng2-forum-demo.firebaseio.com';
+const testUrl = 'https://ng2-forum-demo.firebaseio.com/';
 
 describe('angularfire', () => {
   describe('FIREBASE_REF', () => {
@@ -22,5 +22,11 @@ describe('angularfire', () => {
       const provider = defaultFirebase(testUrl);
       expect(provider).toBeAnInstanceOf(Provider);
     });
+    
+    it('should inject a FIR reference', () => {
+      const injector = Injector.resolveAndCreate([defaultFirebase(testUrl), FIREBASE_PROVIDERS]);
+      expect(injector.get(FirebaseRef).toString()).toBe(testUrl);  
+    });
   });
+  
 });

--- a/src/angularfire.spec.ts
+++ b/src/angularfire.spec.ts
@@ -1,17 +1,26 @@
-import {describe,it,beforeEach} from 'angular2/testing';
-import {Injector, provide} from 'angular2/core';
-import {FIREBASE_PROVIDERS, FirebaseUrl, FirebaseRef} from './angularfire';
+import {describe,it,beforeEach, expect} from 'angular2/testing';
+import {Injector, provide, Provider} from 'angular2/core';
+import {FIREBASE_PROVIDERS, FirebaseUrl, FirebaseRef, defaultFirebase} from './angularfire';
+
+const testUrl = 'https://ng2-forum-demo.firebaseio.com';
 
 describe('angularfire', () => {
   describe('FIREBASE_REF', () => {
     it('should provide a FirebaseRef for the FIREBASE_REF binding', () => {
       var injector = Injector.resolveAndCreate([
         provide(FirebaseUrl, {
-          useValue: 'https://ng2-forum-demo.firebaseio.com'
+          useValue: testUrl
         }),
         FIREBASE_PROVIDERS
       ]);
       expect(typeof injector.get(FirebaseRef).on).toBe('function');
     })
+  });
+  
+  describe('defaultFirebase', () => {
+    it('should create a provider', () => {
+      const provider = defaultFirebase(testUrl);
+      expect(provider).toBeAnInstanceOf(Provider);
+    });
   });
 });

--- a/src/angularfire.ts
+++ b/src/angularfire.ts
@@ -10,6 +10,12 @@ export const FIREBASE_PROVIDERS:any[] = [
     deps: [FirebaseUrl]})
 ];
 
+export const defaultFirebase = (url: string) => {
+  return provide(FirebaseUrl, {
+    useValue: url
+  });
+};
+
 export {FirebaseList, FirebaseListConfig} from './providers/firebase_list';
 export {FirebaseObservable} from './utils/firebase_observable';
 

--- a/src/angularfire.ts
+++ b/src/angularfire.ts
@@ -1,4 +1,4 @@
-import {OpaqueToken, provide} from 'angular2/core';
+import {OpaqueToken, provide, Provider} from 'angular2/core';
 import * as Firebase from 'firebase';
 
 export const FirebaseUrl = new OpaqueToken('FirebaseUrl');
@@ -10,7 +10,7 @@ export const FIREBASE_PROVIDERS:any[] = [
     deps: [FirebaseUrl]})
 ];
 
-export const defaultFirebase = (url: string) => {
+export const defaultFirebase = (url: string):Provider => {
   return provide(FirebaseUrl, {
     useValue: url
   });


### PR DESCRIPTION
@jeffbcross 

Addresses #24. 

You can now do:

```js
providers: [defaultFirebase('https://myfirebase.firebaseio.com/')]
```

There's even tests.