### PR TITLE
feat(auth): Add Observable auth wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ bootstrap(App, [
 ]);
 ```
 
+### FirebaseAuth
+
+Injectable service for managing authentication state. It currently only supports
+reading auth state.
+
+Type: `class FirebaseAuth extends ReplaySubject<FirebaseAuthState>`
+
+Usage:
+```Typescript
+import {FirebaseAuth} from 'angularfire2';
+@Component({
+  selector: 'auth-status',
+  template: `
+    <div *ng-if="auth | async">You are logged in</div>
+    <div *ng-if="!(auth | async)">Please log in</div>
+  `
+})
+class App {
+  constructor (@Inject(FirebaseAuth) public auth: FirebaseAuth) {}
+}
+```
+
 ### FirebaseListConfig
 
 Interface for config object that can be provided to `FirebaseList`

--- a/src/angularfire.ts
+++ b/src/angularfire.ts
@@ -1,16 +1,16 @@
 import {OpaqueToken, provide, Provider} from 'angular2/core';
+import {FirebaseAuth} from './providers/auth';
 import * as Firebase from 'firebase';
-
-export const FirebaseUrl = new OpaqueToken('FirebaseUrl');
-export const FirebaseRef = new OpaqueToken('FirebaseRef');
+import {FirebaseUrl, FirebaseRef} from './tokens';
 
 export const FIREBASE_PROVIDERS:any[] = [
   provide(FirebaseRef, {
     useFactory: (url:string) => new Firebase(url),
-    deps: [FirebaseUrl]})
+    deps: [FirebaseUrl]}),
+  FirebaseAuth
 ];
 
-export const defaultFirebase = (url: string):Provider => {
+export const defaultFirebase = (url: string): Provider => {
   return provide(FirebaseUrl, {
     useValue: url
   });
@@ -18,8 +18,16 @@ export const defaultFirebase = (url: string):Provider => {
 
 export {FirebaseList, FirebaseListConfig} from './providers/firebase_list';
 export {FirebaseObservable} from './utils/firebase_observable';
+export {
+  FirebaseAuth,
+  FirebaseAuthState,
+  FirebaseAuthDataGithub,
+  AuthProviders
+} from './providers/auth';
+export {FirebaseUrl, FirebaseRef} from './tokens';
 
 // Helps Angular-CLI automatically add providers
 export default {
   providers: FIREBASE_PROVIDERS
 }
+

--- a/src/providers/auth.spec.ts
+++ b/src/providers/auth.spec.ts
@@ -1,0 +1,102 @@
+import {expect, describe,it,beforeEach} from 'angular2/testing';
+import {Injector, provide} from 'angular2/core';
+import {Observable} from 'rxjs/Observable'
+import {
+  FIREBASE_PROVIDERS,
+  FirebaseRef,
+  FirebaseUrl,
+  FirebaseAuth,
+  FirebaseAuthState,
+  FirebaseAuthDataGithub,
+  AuthProviders
+} from '../angularfire';
+import * as Firebase from 'firebase';
+
+describe('FirebaseAuth', () => {
+  let injector: Injector = null;
+  let ref: Firebase = null;
+  let authData: any = null;
+  let authCb: any = null;
+
+  const providerMetadata = {
+    accessToken: 'accessToken',
+    displayName: 'github User',
+    username: 'githubUsername',
+    id: '12345'
+  }
+  const authState = {
+    provider: 'github',
+    uid: 'github:12345',
+    github: providerMetadata
+  };
+
+  beforeEach (() => {
+    authData = null;
+    authCb = null;
+    injector = Injector.resolveAndCreate([
+      provide(FirebaseUrl, {
+        useValue: 'https://ng2-forum-demo.firebaseio.com'
+      }),
+      FIREBASE_PROVIDERS
+    ]);
+    ref = injector.get(FirebaseRef);
+    spyOn(ref, 'onAuth').and.callFake((fn: (a: any) => void) => {
+      authCb = fn;
+      authCb(authData);
+    });
+  });
+
+  it('should be an observable', () => {
+    expect(injector.get(FirebaseAuth)).toBeAnInstanceOf(Observable);
+  })
+
+  describe('AuthState', () => {
+    function updateAuthState(_authData: any): void {
+      authData = _authData;
+      if (authCb !== null) {
+        authCb(authData);
+      }
+    }
+
+    it('should synchronously load firebase auth data', () => {
+      updateAuthState(authState);
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith({
+        provider: AuthProviders.Github,
+        uid: 'github:12345',
+        github: providerMetadata
+      });
+    });
+
+    it('should be null if user is not authed', () => {
+      let auth = injector.get(FirebaseAuth);
+      let nextSpy = jasmine.createSpy('nextSpy');
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should emit auth updates', (done: () => void) => {
+      let auth = injector.get(FirebaseAuth);
+      let nextSpy = jasmine.createSpy('nextSpy');
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(null);
+      setTimeout(() => {
+        nextSpy.calls.reset();
+
+        updateAuthState(authState);
+        expect(nextSpy).toHaveBeenCalledWith({
+          provider: AuthProviders.Github,
+          uid: 'github:12345',
+          github: providerMetadata
+        });
+        done();
+      }, 1);
+    });
+  });
+});
+

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -1,0 +1,56 @@
+import {Provider, Inject} from 'angular2/core';
+import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {FirebaseRef} from '../tokens';
+
+import * as Firebase from 'firebase';
+
+const kBufferSize = 1; 
+
+export enum AuthProviders {
+  Github
+};
+
+export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
+  constructor (@Inject(FirebaseRef) private _fbRef: Firebase) {
+    super (kBufferSize);
+
+    this._fbRef.onAuth((authData) => this._emitAuthData(authData));
+  }
+
+  private _emitAuthData(authData: FirebaseAuthDataAllProviders): void {
+    if (authData == null) {
+      this.next(null);
+    } else {
+      let {uid, provider, github} = authData;
+      let authState: FirebaseAuthState = {uid, provider: null};
+      switch (provider) {
+        case "github":
+          authState.github = github;
+          authState.provider = AuthProviders.Github;
+          break;
+        default:
+          throw new Error(`Unsupported firebase auth provider ${provider}`);
+      }
+      this.next(authState);
+    }
+  }
+}
+
+export interface FirebaseAuthState {
+  uid: string;
+  provider: AuthProviders;
+  github?: FirebaseAuthDataGithub;
+}
+
+export interface FirebaseAuthDataGithub {
+  id: string;
+  username: string;
+  accessToken: string;
+  displayName?: string;
+  scope?: [string];
+}
+
+// Firebase only provides typings for 
+interface FirebaseAuthDataAllProviders extends FirebaseAuthData {
+  github?: FirebaseAuthDataGithub;
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,0 +1,4 @@
+import {OpaqueToken} from 'angular2/core';
+
+export const FirebaseUrl = new OpaqueToken('FirebaseUrl');
+export const FirebaseRef= new OpaqueToken('FirebaseRef')


### PR DESCRIPTION
Supports subscribing to auth state. Only supports github provider at the
moment.

Paired with @jeffbcross 

Part of #4 