### PR TITLE
feat(auth): Add WebWorker authentication support

### DIFF
--- a/src/angularfire2.spec.ts
+++ b/src/angularfire2.spec.ts
@@ -10,6 +10,7 @@ import {Injector, provide, Provider} from 'angular2/core';
 import {
   AngularFire,
   FIREBASE_PROVIDERS,
+  WORKER_APP_FIREBASE_PROVIDERS,
   FirebaseAuth,
   FirebaseUrl,
   FirebaseRef,

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -1,9 +1,13 @@
-import {Inject, Injectable, OpaqueToken, provide, Provider} from 'angular2/core';
+import {APP_INITIALIZER, Inject, Injectable, OpaqueToken, provide, Provider} from 'angular2/core';
 import {FirebaseAuth} from './providers/auth';
 import * as Firebase from 'firebase';
 import {FirebaseListObservable} from './utils/firebase_list_observable';
 import {FirebaseListFactory, FirebaseListFactoryOpts} from './utils/firebase_list_factory';
 import {FirebaseUrl, FirebaseRef} from './tokens';
+import {AuthBackend} from './providers/auth_backend';
+import {FirebaseSdkAuthBackend} from './providers/firebase_sdk_auth_backend';
+import {WebWorkerFirebaseAuth} from './providers/web_workers/worker/auth';
+import {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';
 
 @Injectable()
 export class AngularFire {
@@ -17,12 +21,34 @@ export class AngularFire {
   }
 }
 
-export const FIREBASE_PROVIDERS:any[] = [
+const COMMON_PROVIDERS: any[] = [
   provide(FirebaseRef, {
     useFactory: (url:string) => new Firebase(url),
     deps: [FirebaseUrl]}),
   FirebaseAuth,
   AngularFire
+];
+
+export const FIREBASE_PROVIDERS:any[] = [
+  COMMON_PROVIDERS,
+  provide(AuthBackend, {
+    useFactory: (ref: Firebase) => new FirebaseSdkAuthBackend(ref, false),
+    deps: [FirebaseRef]
+  })
+];
+
+export const WORKER_APP_FIREBASE_PROVIDERS: any[] = [
+  COMMON_PROVIDERS,
+  provide(AuthBackend, {useClass: WebWorkerFirebaseAuth})
+];
+
+export const WORKER_RENDER_FIREBASE_PROVIDERS: any[] = [
+  COMMON_PROVIDERS,
+  provide(FirebaseSdkAuthBackend, {
+    useFactory: (ref: Firebase) => new FirebaseSdkAuthBackend(ref, true),
+    deps: [FirebaseRef]
+  }),
+  MessageBasedFirebaseAuth
 ];
 
 export const defaultFirebase = (url: string): Provider => {
@@ -34,12 +60,15 @@ export const defaultFirebase = (url: string): Provider => {
 export {FirebaseListObservable} from './utils/firebase_list_observable';
 export {
   FirebaseAuth,
+  firebaseAuthConfig
+} from './providers/auth';
+export {
   FirebaseAuthState,
   AuthMethods,
   AuthProviders,
-  firebaseAuthConfig
-} from './providers/auth';
+} from './providers/auth_backend';
 export {FirebaseUrl, FirebaseRef, FirebaseAuthConfig} from './tokens';
+export {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';
 
 // Helps Angular-CLI automatically add providers
 export default {

--- a/src/providers/auth.spec.ts
+++ b/src/providers/auth.spec.ts
@@ -13,6 +13,8 @@ import {
   firebaseAuthConfig,
   AuthProviders
 } from '../angularfire2';
+import {AuthBackend} from './auth_backend';
+import {FirebaseSdkAuthBackend} from './firebase_sdk_auth_backend';
 import * as Firebase from 'firebase';
 import * as mockPromises from 'mock-promises';
 
@@ -21,6 +23,7 @@ describe('FirebaseAuth', () => {
   let ref: Firebase = null;
   let authData: any = null;
   let authCb: any = null;
+  let backend: AuthBackend = null;
 
   const providerMetadata = {
     accessToken: 'accessToken',
@@ -74,7 +77,7 @@ describe('FirebaseAuth', () => {
           authCb(authData);
         }
       });
-
+      backend = new FirebaseSdkAuthBackend(ref);
     });
     function updateAuthState(_authData: any): void {
       authData = _authData;
@@ -144,6 +147,7 @@ describe('FirebaseAuth', () => {
           'unauth','getAuth', 'onAuth', 'offAuth',
           'createUser','changePassword','changeEmail','removeUser','resetPassword'
         ]);
+        backend = new FirebaseSdkAuthBackend(ref);
     });
 
     it('should return a provider', () => {
@@ -154,7 +158,7 @@ describe('FirebaseAuth', () => {
       let config= {
         method: AuthMethods.Anonymous
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       auth.login();
       expect(ref.authAnonymously).toHaveBeenCalled();
     });
@@ -164,7 +168,7 @@ describe('FirebaseAuth', () => {
         method: AuthMethods.Anonymous,
         remember: 'default'
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       auth.login();
       expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), {remember: 'default'});
     });
@@ -173,7 +177,7 @@ describe('FirebaseAuth', () => {
       let config = {
         method: AuthMethods.Anonymous
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       auth.login({
         method: AuthMethods.Popup,
         provider: AuthProviders.Google
@@ -187,7 +191,7 @@ describe('FirebaseAuth', () => {
         provider: AuthProviders.Google,
         scope: ['email']
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       auth.login({
         provider: AuthProviders.Github
       });
@@ -210,7 +214,8 @@ describe('FirebaseAuth', () => {
           'unauth','getAuth', 'onAuth', 'offAuth',
           'createUser','changePassword','changeEmail','removeUser','resetPassword'
         ]);
-      auth = new FirebaseAuth(ref);
+      backend = new FirebaseSdkAuthBackend(ref);
+      auth = new FirebaseAuth(backend);
 
       result = null;
       status = null;
@@ -235,7 +240,7 @@ describe('FirebaseAuth', () => {
       let config = {
         method: AuthMethods.Password
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       let promise = wrapPromise(auth.login());
       mockPromises.executeForPromise(promise);
       expect(failure).not.toBeNull();
@@ -245,7 +250,7 @@ describe('FirebaseAuth', () => {
       let config = {
         method: AuthMethods.CustomToken
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       let promise = wrapPromise(auth.login());
       mockPromises.executeForPromise(promise);
       expect(failure).not.toBeNull();
@@ -255,7 +260,7 @@ describe('FirebaseAuth', () => {
       let config = {
         method: AuthMethods.OAuthToken
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       let promise = wrapPromise(auth.login());
       mockPromises.executeForPromise(promise);
       expect(failure).not.toBeNull();
@@ -265,7 +270,7 @@ describe('FirebaseAuth', () => {
       let config = {
         method: AuthMethods.Redirect
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       let promise = wrapPromise(auth.login());
       mockPromises.executeForPromise(promise);
       expect(failure).not.toBeNull();
@@ -275,7 +280,7 @@ describe('FirebaseAuth', () => {
       let config = {
         method: AuthMethods.Popup
       };
-      let auth = new FirebaseAuth(ref, config);
+      let auth = new FirebaseAuth(backend, config);
       let promise = wrapPromise(auth.login());
       mockPromises.executeForPromise(promise);
       expect(failure).not.toBeNull();

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -2,29 +2,21 @@ import {Provider, Inject, provide, Injectable, Optional} from 'angular2/core';
 import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
 import {FirebaseRef, FirebaseAuthConfig} from '../tokens';
 import {isPresent} from '../utils/utils';
-
-import * as Firebase from 'firebase';
+import {
+  AuthBackend,
+  AuthProviders,
+  AuthMethods,
+  OAuthCredentials,
+  OAuth1Credentials,
+  OAuth2Credentials,
+  AuthCredentials,
+  FirebaseAuthState,
+  AuthConfiguration,
+  FirebaseAuthDataAllProviders,
+  authDataToAuthState
+} from './auth_backend';
 
 const kBufferSize = 1;
-
-export enum AuthProviders {
-  Github,
-  Twitter,
-  Facebook,
-  Google,
-  Password,
-  Anonymous,
-  Custom
-};
-
-export enum AuthMethods {
-  Popup,
-  Redirect,
-  Anonymous,
-  Password,
-  OAuthToken,
-  CustomToken
-};
 
 export const firebaseAuthConfig = (config: AuthConfiguration): Provider => {
   return provide(FirebaseAuthConfig, {
@@ -34,11 +26,11 @@ export const firebaseAuthConfig = (config: AuthConfiguration): Provider => {
 
 @Injectable()
 export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
-  constructor (@Inject(FirebaseRef) private _fbRef: Firebase,
+  constructor (private _authBackend: AuthBackend,
                @Optional() @Inject(FirebaseAuthConfig) private _config?: AuthConfiguration) {
     super (kBufferSize);
 
-    this._fbRef.onAuth((authData) => this._emitAuthData(authData));
+    this._authBackend.onAuth((authData) => this._emitAuthData(authData));
   }
 
   public login(config?: AuthConfiguration): Promise<FirebaseAuthState>;
@@ -74,25 +66,25 @@ export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
 
     switch (config.method) {
       case AuthMethods.Popup:
-        return this._authWithOAuthPopup(config.provider, this._scrubConfig(config));
+        return this._authBackend.authWithOAuthPopup(config.provider, this._scrubConfig(config));
       case AuthMethods.Redirect:
-        return this._authWithOAuthRedirect(config.provider, this._scrubConfig(config));
+        return this._authBackend.authWithOAuthRedirect(config.provider, this._scrubConfig(config));
       case AuthMethods.Anonymous:
-        return this._authAnonymously(this._scrubConfig(config));
+        return this._authBackend.authAnonymously(this._scrubConfig(config));
       case AuthMethods.Password:
-        return this._authWithPassword(<FirebaseCredentials> credentials, this._scrubConfig(config, false));
+        return this._authBackend.authWithPassword(<FirebaseCredentials> credentials, this._scrubConfig(config, false));
       case AuthMethods.OAuthToken:
-        return this._authWithOAuthToken(config.provider, <OAuthCredentials> credentials,
+        return this._authBackend.authWithOAuthToken(config.provider, <OAuthCredentials> credentials,
                                          this._scrubConfig(config));
       case AuthMethods.CustomToken:
-        return this._authWithCustomToken((<OAuth2Credentials> credentials).token,
+        return this._authBackend.authWithCustomToken((<OAuth2Credentials> credentials).token,
                                          this._scrubConfig(config, false));
     }
   }
 
   public logout(): void {
-    if (this._fbRef.getAuth() !== null) {
-      this._fbRef.unauth();
+    if (this._authBackend.getAuth() !== null) {
+      this._authBackend.unauth();
     }
   }
 
@@ -127,175 +119,7 @@ export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
     if (authData == null) {
       this.next(null);
     } else {
-      this.next(this._authDataToAuthState(authData));
+      this.next(authDataToAuthState(authData));
     }
   }
-
-  private _authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
-    let p = new Promise((res, rej) => {
-      this._fbRef.authWithCustomToken(token, this._handleFirebaseCb(res, rej), options);
-    });
-
-    return p;
-  }
-
-  private _authAnonymously(options?: any): Promise<FirebaseAuthState> {
-    let p = new Promise((res, rej) => {
-      this._fbRef.authAnonymously(this._handleFirebaseCb(res, rej), options);
-    });
-
-    return p;
-  }
-
-  private _authWithPassword(credentials: FirebaseCredentials, options?: any)
-    : Promise<FirebaseAuthState> {
-    let p = new Promise((res, rej) => {
-      this._fbRef.authWithPassword(credentials, this._handleFirebaseCb(res, rej), options);
-    });
-
-    return p;
-  }
-
-  private _authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
-    let p = new Promise((res, rej) => {
-      this._fbRef.authWithOAuthPopup(this._providerToString(provider),
-                                     this._handleFirebaseCb(res, rej), options);
-    });
-
-    return p;
-  }
-
-  /**
-   * Authenticates a Firebase client using a redirect-based OAuth flow
-   * NOTE: This promise will not be resolved if authentication is successful since the browser redirected.
-   * You should subscribe to the FirebaseAuth object to listen succesful login
-   */
-  private _authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
-    let p = new Promise((res, rej) => {
-      this._fbRef.authWithOAuthRedirect(this._providerToString(provider),
-                                        this._handleFirebaseCb(res, rej), options);
-    });
-
-    return p;
-  }
-
-  private _authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
-  : Promise<FirebaseAuthState> {
-    let p = new Promise((res, rej) => {
-      let credentials = isPresent((<OAuth2Credentials>credentialsObj).token)
-                        ? (<OAuth2Credentials> credentialsObj).token 
-                        : credentialsObj;
-      this._fbRef.authWithOAuthToken(this._providerToString(provider), credentials,
-                                     this._handleFirebaseCb(res, rej), options);
-    });
-
-    return p;
-  }
-
-  private _providerToString(provider: AuthProviders): string {
-    switch (provider) {
-      case AuthProviders.Github:
-        return 'github';
-      case AuthProviders.Twitter:
-        return 'twitter';
-      case AuthProviders.Facebook:
-        return 'facebook';
-      case AuthProviders.Google:
-        return 'google';
-      default: 
-        throw new Error(`Unsupported firebase auth provider ${provider}`);
-    }
-  }
-
-  private _handleFirebaseCb(res: Function, rej: Function): (err: any, auth?: FirebaseAuthData) => void {
-    return (err, auth?) => {
-      if (err) {
-        return rej (err);
-      } else {
-        return res (this._authDataToAuthState(auth));
-      }
-    };
-  }
-
-  private _authDataToAuthState(authData: FirebaseAuthDataAllProviders): FirebaseAuthState {
-    let {auth, uid, provider, github, twitter, facebook, google, password, anonymous} = authData;
-    let authState: FirebaseAuthState = {auth, uid, provider: null};
-    switch (provider) {
-      case 'github':
-        authState.github = github;
-        authState.provider = AuthProviders.Github;
-        break;
-      case 'twitter':
-        authState.twitter = twitter;
-        authState.provider = AuthProviders.Twitter;
-        break;
-      case 'facebook':
-        authState.facebook = facebook;
-        authState.provider = AuthProviders.Facebook;
-        break;
-      case 'google':
-        authState.google = google;
-        authState.provider = AuthProviders.Google;
-        break;
-      case 'password':
-        authState.password = password;
-        authState.provider = AuthProviders.Password;
-        break;
-      case 'anonymous':
-        authState.anonymous = anonymous;
-        authState.provider = AuthProviders.Anonymous;
-        break;
-      case 'custom':
-        authState.provider = AuthProviders.Custom;
-        break;
-      default:
-        throw new Error(`Unsupported firebase auth provider ${provider}`);
-    }
-
-    return authState;
-  }
-}
-
-export interface AuthConfiguration {
-  method?: AuthMethods;
-  provider?: AuthProviders;
-  remember?: string;
-  scope?: string[];
-}
-
-export interface OAuth2Credentials {
-  token: string;
-}
-
-export interface OAuth1Credentials {
-  user_id: string;
-  oauth_token: string;
-  oauth_token_secret: string;
-}
-
-export type OAuthCredentials = OAuth1Credentials | OAuth2Credentials;
-
-export type AuthCredentials = FirebaseCredentials | OAuthCredentials;
-
-export interface FirebaseAuthState {
-  uid: string;
-  provider: AuthProviders;
-	auth: Object;
-  expires?: number;
-  github?: any;
-	google?: any;
-  twitter?: any;
-  facebook?: any;
-  password?: any;
-  anonymous?: any;
-}
-
-// Firebase only provides typings for google
-interface FirebaseAuthDataAllProviders extends FirebaseAuthData {
-  github?: any;
-  twitter?: any;
-  google?: any;
-  facebook?: any;
-  password?: any;
-  anonymous?: any;
 }

--- a/src/providers/auth_backend.ts
+++ b/src/providers/auth_backend.ts
@@ -1,0 +1,115 @@
+export abstract class AuthBackend {
+  abstract authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState>;
+  abstract authAnonymously(options?: any): Promise<FirebaseAuthState>;
+  abstract authWithPassword(credentials: FirebaseCredentials, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+  : Promise<FirebaseAuthState>;
+  abstract onAuth(onComplete: (authData: FirebaseAuthData) => void): void;
+  abstract getAuth(): FirebaseAuthData;
+  abstract unauth(): void;
+}
+
+// Firebase only provides typings for google
+export interface FirebaseAuthDataAllProviders extends FirebaseAuthData {
+  github?: any;
+  twitter?: any;
+  google?: any;
+  facebook?: any;
+  password?: any;
+  anonymous?: any;
+}
+
+export enum AuthProviders {
+  Github,
+  Twitter,
+  Facebook,
+  Google,
+  Password,
+  Anonymous,
+  Custom
+};
+
+export enum AuthMethods {
+  Popup,
+  Redirect,
+  Anonymous,
+  Password,
+  OAuthToken,
+  CustomToken
+};
+
+
+export interface AuthConfiguration {
+  method?: AuthMethods;
+  provider?: AuthProviders;
+  remember?: string;
+  scope?: string[];
+}
+
+export interface OAuth2Credentials {
+  token: string;
+}
+
+export interface OAuth1Credentials {
+  user_id: string;
+  oauth_token: string;
+  oauth_token_secret: string;
+}
+
+export type OAuthCredentials = OAuth1Credentials | OAuth2Credentials;
+
+export type AuthCredentials = FirebaseCredentials | OAuthCredentials;
+
+export interface FirebaseAuthState {
+  uid: string;
+  provider: AuthProviders;
+	auth: Object;
+  expires?: number;
+  github?: any;
+	google?: any;
+  twitter?: any;
+  facebook?: any;
+  password?: any;
+  anonymous?: any;
+}
+
+export function authDataToAuthState(authData: FirebaseAuthDataAllProviders): FirebaseAuthState {
+  let {auth, uid, provider, github, twitter, facebook, google, password, anonymous} = authData;
+  let authState: FirebaseAuthState = {auth, uid, provider: null};
+  switch (provider) {
+    case 'github':
+      authState.github = github;
+      authState.provider = AuthProviders.Github;
+      break;
+    case 'twitter':
+      authState.twitter = twitter;
+      authState.provider = AuthProviders.Twitter;
+      break;
+    case 'facebook':
+      authState.facebook = facebook;
+      authState.provider = AuthProviders.Facebook;
+      break;
+    case 'google':
+      authState.google = google;
+      authState.provider = AuthProviders.Google;
+      break;
+    case 'password':
+      authState.password = password;
+      authState.provider = AuthProviders.Password;
+      break;
+    case 'anonymous':
+      authState.anonymous = anonymous;
+      authState.provider = AuthProviders.Anonymous;
+      break;
+    case 'custom':
+      authState.provider = AuthProviders.Custom;
+      break;
+    default:
+      throw new Error(`Unsupported firebase auth provider ${provider}`);
+  }
+
+  return authState;
+}
+

--- a/src/providers/firebase_sdk_auth_backend.ts
+++ b/src/providers/firebase_sdk_auth_backend.ts
@@ -1,0 +1,128 @@
+import {Injectable, Inject} from 'angular2/core';
+import {
+  AuthBackend,
+  FirebaseAuthState,
+  AuthProviders,
+  AuthMethods,
+  authDataToAuthState,
+  OAuth2Credentials,
+  OAuthCredentials
+} from './auth_backend';
+import {FirebaseRef} from '../tokens';
+import {isPresent} from '../utils/utils';
+import * as Firebase from 'firebase';
+
+@Injectable()
+export class FirebaseSdkAuthBackend extends AuthBackend{
+  constructor (@Inject(FirebaseRef) private _fbRef: Firebase,
+              private _webWorkerMode = false) {
+    super();
+  }
+
+  onAuth(onComplete: (authData: FirebaseAuthData) => void): void {
+    this._fbRef.onAuth(onComplete);
+  }
+
+  getAuth(): FirebaseAuthData {
+    return this._fbRef.getAuth();
+  }
+
+  unauth(): void {
+    this._fbRef.unauth();
+  }
+
+  authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(token, this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authAnonymously(options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authAnonymously(this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithPassword(credentials: FirebaseCredentials, options?: any)
+    : Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithPassword(credentials, this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithOAuthPopup(this._providerToString(provider),
+                                     this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  /**
+   * Authenticates a Firebase client using a redirect-based OAuth flow
+   * NOTE: This promise will not be resolved if authentication is successful since the browser redirected.
+   * You should subscribe to the FirebaseAuth object to listen succesful login
+   */
+  authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithOAuthRedirect(this._providerToString(provider),
+                                        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+  : Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      let credentials = isPresent((<OAuth2Credentials>credentialsObj).token)
+                        ? (<OAuth2Credentials> credentialsObj).token 
+                        : credentialsObj;
+      this._fbRef.authWithOAuthToken(this._providerToString(provider), credentials,
+                                     this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  private _handleFirebaseCb(res: Function, rej: Function, options: any): (err: any, auth?: FirebaseAuthData) => void {
+    return (err, auth?) => {
+      if (err) {
+        return rej (err);
+      } else {
+        if (!this._webWorkerMode)
+          return res (authDataToAuthState(auth));
+        else {
+          if (isPresent(options) && isPresent(options.remember)) {
+            // Add remember value in WebWorker mode so that the worker
+            // can auth with the same value
+            (<any> auth).remember = options.remember;
+          }
+          return res(auth);
+        }
+      }
+    };
+  }
+
+  private _providerToString(provider: AuthProviders): string {
+    switch (provider) {
+      case AuthProviders.Github:
+        return 'github';
+      case AuthProviders.Twitter:
+        return 'twitter';
+      case AuthProviders.Facebook:
+        return 'facebook';
+      case AuthProviders.Google:
+        return 'google';
+      default: 
+        throw new Error(`Unsupported firebase auth provider ${provider}`);
+    }
+  }
+}

--- a/src/providers/web_workers/shared/channels.ts
+++ b/src/providers/web_workers/shared/channels.ts
@@ -1,0 +1,2 @@
+export const AUTH_CHANNEL = 'angularfire2-auth';
+export const INITIAL_AUTH_CHANNEL = 'angularfire2-auth-initial';

--- a/src/providers/web_workers/ui/auth.ts
+++ b/src/providers/web_workers/ui/auth.ts
@@ -1,0 +1,35 @@
+import {Injectable, Inject} from 'angular2/core';
+import {ServiceMessageBrokerFactory, PRIMITIVE} from 'angular2/platform/worker_render';
+import {AUTH_CHANNEL, INITIAL_AUTH_CHANNEL} from '../shared/channels';
+import {FirebaseRef} from '../../../tokens';
+import {FirebaseAuthState} from '../../auth_backend';
+import {FirebaseSdkAuthBackend} from '../../firebase_sdk_auth_backend';
+
+@Injectable()
+export class MessageBasedFirebaseAuth {
+  constructor(private _sdkBackend: FirebaseSdkAuthBackend,
+              private _brokerFactory: ServiceMessageBrokerFactory) {
+  }
+
+  start(): void {
+    let broker = this._brokerFactory.createMessageBroker(AUTH_CHANNEL);
+    broker.registerMethod('authAnonymously', [PRIMITIVE], this._sdkBackend.authAnonymously.bind(this._sdkBackend),
+                          PRIMITIVE);
+    broker.registerMethod('authWithPassword', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithPassword.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthPopup', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthPopup.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthRedirect', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthRedirect.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthToken', [PRIMITIVE, PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthToken.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('getAuth', null, this._getAuth.bind(this), PRIMITIVE);
+    broker.registerMethod('unauth', null, this._sdkBackend.unauth.bind(this._sdkBackend));
+  }
+
+  private _getAuth(): Promise<FirebaseAuthData> {
+    return new Promise((res, rej) => {
+      res(this._sdkBackend.getAuth());
+    });
+  }
+}

--- a/src/providers/web_workers/worker/auth.ts
+++ b/src/providers/web_workers/worker/auth.ts
@@ -1,0 +1,135 @@
+import {Injectable, Inject} from 'angular2/core';
+
+// Import these from src/ until we have a specific import path for them
+// https://github.com/angular/angular/issues/7419
+import {
+  ClientMessageBrokerFactory,
+  ClientMessageBroker,
+  FnArg,
+  UiArguments
+} from 'angular2/src/web_workers/shared/client_message_broker';
+import {MessageBus} from 'angular2/src/web_workers/shared/message_bus';
+import {PRIMITIVE} from 'angular2/src/web_workers/shared/serializer';
+
+import {AUTH_CHANNEL, INITIAL_AUTH_CHANNEL} from '../shared/channels';
+import {FirebaseRef} from '../../../tokens';
+import {
+  AuthBackend,
+  FirebaseAuthState,
+  AuthProviders,
+  AuthMethods,
+  authDataToAuthState,
+  OAuth2Credentials,
+  OAuthCredentials
+} from '../../auth_backend';
+import {isPresent} from '../../../utils/utils';
+import * as Firebase from 'firebase';
+
+@Injectable()
+export class WebWorkerFirebaseAuth extends AuthBackend {
+  private _messageBroker: ClientMessageBroker;
+  private _authMetadata: {[key: string]: FirebaseAuthData} = {};
+  private _authCbs: Array<(authData: FirebaseAuthData) => void> = [];
+  private _gotAuth = false;
+
+  constructor (@Inject(FirebaseRef) private _fbRef: Firebase, brokerFactory: ClientMessageBrokerFactory,
+              bus: MessageBus) {
+    super();
+    this._messageBroker = brokerFactory.createMessageBroker(AUTH_CHANNEL);
+    let args = new UiArguments('getAuth');
+    this._messageBroker.runOnService(args, PRIMITIVE).then((authData: FirebaseAuthDataWithRemember) => {
+      this._gotAuth = true;
+      if (authData != null) {
+        this._handleAuthPromise(<FirebaseAuthDataWithRemember> authData);
+      }
+    });
+  }
+
+  onAuth (onComplete: (authData: FirebaseAuthData) => void): void {
+    this._fbRef.onAuth((authData) => {
+      if (!this._gotAuth) return false;
+      if (isPresent(authData) && isPresent(this._authMetadata[authData.token])) {
+        authData = this._authMetadata[authData.token];
+      }
+      onComplete(authData);
+    });
+  }
+
+  getAuth(): FirebaseAuthData {
+    return this._fbRef.getAuth();
+  }
+
+  authAnonymously(options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authAnonymously', [new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+
+  authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
+    return new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(token, (err, authData) => {
+        if (err)
+          return rej(err);
+        else
+          return res(authDataToAuthState(authData));
+      });
+    });
+  }
+  authWithPassword(credentials: FirebaseCredentials, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithPassword',
+                               [new FnArg(credentials, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthPopup',
+                               [new FnArg(provider, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthRedirect',
+                               [new FnArg(provider, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+  : Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthToken',
+                               [new FnArg(provider, PRIMITIVE), 
+                                new FnArg(credentialsObj, PRIMITIVE),
+                                new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+
+  unauth(): void {
+    let args = new UiArguments('unauth');
+    this._messageBroker.runOnService(args, null);
+    this._fbRef.unauth();
+  }
+
+  /**
+   * Performs custom token auth using the token returned from the UI.
+   * Saves the associated metatadata to be emited by onAuth.
+   */
+  private _doAuth(promise: Promise<FirebaseAuthDataWithRemember>): Promise<FirebaseAuthState> {
+    return promise.then((data) => this._handleAuthPromise(data));
+  }
+
+  private _handleAuthPromise(authData: FirebaseAuthDataWithRemember): Promise<FirebaseAuthState> {
+    this._authMetadata[authData.token] = authData;
+    return new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(authData.token, (err, _) => {
+        if (err)
+          return rej (err);
+        else 
+          return res(authDataToAuthState(authData));
+      }, {remember: authData.remember});
+    });
+  }
+}
+
+interface FirebaseAuthDataWithRemember extends FirebaseAuthData {
+  remember: string;
+}


### PR DESCRIPTION
In lieu of official WebWorker support in the Firebase SDK, we're proxying auth requests to the UI and then replaying them using custom token on the worker.