### PR TITLE
DUPLICATE fix(FirebaseListFactory): emit initial data only once

### DIFF
--- a/src/utils/firebase_list_factory.ts
+++ b/src/utils/firebase_list_factory.ts
@@ -3,24 +3,42 @@ import {Observer} from 'rxjs/Observer';
 import * as Firebase from 'firebase';
 
 export function FirebaseListFactory (absoluteUrl:string, {preserveSnapshot}:FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
-  var ref = new Firebase(absoluteUrl);
+  const ref = new Firebase(absoluteUrl);
   return new FirebaseListObservable((obs:Observer<any[]>) => {
-    var arr:any[] = [];
+    let arr:any[] = [];
+    let hasInitialLoad = false;
+
+    // The list should only emit after the initial load
+    // comes down from the Firebase database, (e.g.) all
+    // the initial child_added events have fired.
+    // This way a complete array is emitted which leads
+    // to better rendering performance
+    ref.once('value', (snap) => {
+      hasInitialLoad = true;
+      obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+    });
 
     ref.on('child_added', (child:any) => {
       arr = onChildAdded(arr, child);
-      obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      // only emit the array after the initial load
+      if (hasInitialLoad) {
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
     });
 
     ref.on('child_removed', (child:any) => {
       arr = onChildRemoved(arr, child)
-      obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      if (hasInitialLoad) {
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
     });
 
     ref.on('child_changed', (child:any, prevKey: string) => {
       arr = onChildChanged(arr, child, prevKey)
-      // This also manages when the only change is prevKey change
-      obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      if (hasInitialLoad) {
+        // This also manages when the only change is prevKey change
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
     });
 
     return () => ref.off();

--- a/src/utils/firebase_object_factory.spec.ts
+++ b/src/utils/firebase_object_factory.spec.ts
@@ -3,43 +3,59 @@ import {FirebaseObjectObservable} from '../utils/firebase_object_observable';
 import {beforeEach, it, describe, expect} from 'angular2/testing';
 import {Subscription} from 'rxjs';
 
-const rootFirebase = 'ws://localhost.firebaseio.test:5000';
+const rootFirebase = 'https://angularfire2.firebaseio-demo.com';
 
 describe('FirebaseObjectFactory', () => {
-  var ref = new Firebase(`${rootFirebase}/questions/1`);
+  var i = 0;
+  var ref:Firebase;
   var observable:FirebaseObjectObservable<any>;
   var subscription:Subscription;
   var nextSpy:jasmine.Spy;
 
   beforeEach((done:any) => {
+    i=Date.now();
+    ref = new Firebase(`${rootFirebase}/questions/${i}`);
     nextSpy = nextSpy = jasmine.createSpy('next');
-    observable = FirebaseObjectFactory(`${rootFirebase}/questions/1`);
+    observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`);
     ref.remove(done);
+  });
+
+  afterEach(() => {
     if (subscription && !subscription.isUnsubscribed) {
       subscription.unsubscribe();
     }
+  })
+
+
+  it('should emit a null value if no value is present when subscribed', (done:any) => {
+    subscription = observable.subscribe(val => {
+      expect(val).toBe(null);
+      done();
+    });
+});
+
+
+  it('should emit unwrapped data by default', (done:any) => {
+    ref.set({unwrapped: 'bar'}, () => {
+      subscription = observable.subscribe(val => {
+        if (!val) return
+        expect(val).toEqual({unwrapped: 'bar'});
+        done();
+      });
+    });
   });
 
 
-  it('should emit a null value if no value is present when subscribed', () => {
-    subscription = observable.subscribe(nextSpy);
-    expect(nextSpy.calls.count()).toBe(1);
-    expect(nextSpy.calls.argsFor(0)[0]).toEqual(null);
-  });
-
-
-  it('should emit unwrapped data by default', () => {
-    ref.set({foo: 'bar'});
-    subscription = observable.subscribe(nextSpy);
-    expect(nextSpy.calls.argsFor(0)[0]).toEqual({foo: 'bar'});
-  });
-
-
-  it('should emit snapshots if preserveSnapshot option is true', () => {
-    observable = FirebaseObjectFactory(`${rootFirebase}/questions/1`, {preserveSnapshot: true});
-    ref.set('hello!');
-    subscription = observable.subscribe(nextSpy);
-    expect(nextSpy.calls.argsFor(0)[0].val()).toEqual('hello!');
+  it('should emit snapshots if preserveSnapshot option is true', (done:any) => {
+    observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`, {preserveSnapshot: true});
+    ref.remove(() => {
+      ref.set('preserved snapshot!', () => {
+        subscription = observable.subscribe(data => {
+          expect(data.val()).toEqual('preserved snapshot!');
+          done();
+        });
+      });
+    })
   });
 
 


### PR DESCRIPTION
Previously, a new array would be emitted for each
child_added event for a ref, even data that was
already available when the list observable was subscribed.
This change waits until the initial set of data has been
loaded by Firebase before emitting the initial array.

Closes #52