### PR TITLE
Auto api docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+docs/api/
 typings/
 npm-debug.log
 .idea/

--- a/CONTRIBUTOR.md
+++ b/CONTRIBUTOR.md
@@ -1,0 +1,31 @@
+## Initial Setup
+
+```
+$ npm install
+$ npm run build
+$ npm test
+```
+
+## Build CJS/ES5 Output
+
+`$ npm run build`
+
+## Run Karma Against CJS/ES5 Output
+
+`$ npm test`
+
+## Build Docs
+
+`$ npm run docs`
+
+## Build and Deploy Docs to Firebase Hosting
+
+(Ask @jeffbcross to add you as a collaborator)
+
+```
+$ npm install -g firebase-tools
+$ firebase login
+$ npm run docs
+$ cd docs
+$ firebase deploy
+```

--- a/docs/firebase.json
+++ b/docs/firebase.json
@@ -1,0 +1,16 @@
+{
+  "firebase": "angular-fire-2",
+  "public": ".",
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/api",
+      "type": 302
+    }
+  ],
+  "ignore": [
+    "firebase.json",
+    "**/.*",
+    "**/node_modules/**"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/angularfire2.js",
   "scripts": {
     "test": "npm run build; karma start",
+    "docs": "typedoc --out docs/api/ --module commonjs --mode modules --name AngularFire2 src",
     "build": "rm -rf dist; tsc && cp package.json README.md LICENSE .npmignore dist/",
     "postbuild": "node tools/rewrite-published-package.js",
     "postinstall": "typings install; webdriver-manager update",
@@ -54,6 +55,7 @@
     "systemjs-builder": "^0.15.7",
     "traceur": "0.0.96",
     "tsd": "^0.6.5",
+    "typedoc": "github:jeffbcross/typedoc",
     "typescript": "1.7.5",
     "typings": "^0.6.2",
     "zone.js": "0.5.15"

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -63,7 +63,10 @@ export const WORKER_RENDER_FIREBASE_PROVIDERS: any[] = [
   }),
   MessageBasedFirebaseAuth
 ];
-
+/**
+ * Used to define the default Firebase root location to be
+ * used throughout an application.
+ */
 export const defaultFirebase = (url: string): Provider => {
   return provide(FirebaseUrl, {
     useValue: url


### PR DESCRIPTION
This PR adds an npm script to generate API docs, and adds firebase hosting configuration to publish API docs to angular-fire-2.firebaseapp.com (soon to be angularfire2.com). 

The API docs are published to /api, and the root of the domain automatically redirects to /api for now, until a proper landing page is implemented. 

The docs are built using my fork of [typedoc](https://github.com/sebastian-lenz/typedoc)

Closes #88