### PR TITLE
feat(AngularFire): support absolute urls in list() and object()

### DIFF
--- a/src/angularfire2.spec.ts
+++ b/src/angularfire2.spec.ts
@@ -51,6 +51,12 @@ describe('angularfire', () => {
       af = _af;
     }));
 
+
+    it('should accept an absolute url', () => {
+      expect((<any>af.list(localServerUrl))._ref.toString()).toBe(localServerUrl);
+    });
+
+
     it('should return an observable of the path', (done:any) => {
       var questions = af.list(`/questions`);
       (<any>questions)._ref.push({pathObservable:true}, () => {
@@ -81,11 +87,18 @@ describe('angularfire', () => {
 
   describe('.object()', () => {
     var observable:FirebaseObjectObservable<any>;
+    var af:AngularFire;
 
     beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
-    beforeEach(inject([AngularFire], (af:AngularFire) => {
-      observable = af.object(`/list-of-questions/1`)
+    beforeEach(inject([AngularFire], (_af:AngularFire) => {
+      observable = _af.object(`/list-of-questions/1`)
+      af = _af;
     }));
+
+
+    it('should accept an absolute url', () => {
+      expect((<any>af.object(localServerUrl))._ref.toString()).toBe(localServerUrl);
+    });
 
 
     it('should return an observable of the path', injectAsync([AngularFire], (af:AngularFire) => {

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -26,12 +26,19 @@ export class AngularFire {
     public auth:FirebaseAuth) {
   }
   list (url:string, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
-    // TODO: check if relative or absolute
-    return FirebaseListFactory(this.fbUrl+url, opts);
+    return FirebaseListFactory(getAbsUrl(this.fbUrl, url), opts);
   }
   object(url: string, opts?:FirebaseObjectFactoryOpts):FirebaseObjectObservable<any> {
-    return FirebaseObjectFactory(this.fbUrl+url, opts);
+    return FirebaseObjectFactory(getAbsUrl(this.fbUrl, url), opts);
   }
+}
+
+function getAbsUrl (root:string, url:string) {
+  if (!(/^[a-z]+:\/\/.*/.test(url))) {
+    // Provided url is relative.
+    url = root + url;
+  }
+  return url;
 }
 
 const COMMON_PROVIDERS: any[] = [


### PR DESCRIPTION
Closes #76