### PR TITLE
fix(worker): Add export for MessageBasedFirebaseAuth to angularfire2/worker_render path

### DIFF
--- a/src/angularfire2_worker_render.ts
+++ b/src/angularfire2_worker_render.ts
@@ -13,3 +13,5 @@ export const WORKER_RENDER_FIREBASE_PROVIDERS: any[] = [
   }),
   MessageBasedFirebaseAuth
 ];
+
+export {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';


### PR DESCRIPTION
Until https://github.com/angular/angular/issues/7420 is implemented users need to manually inject this service and start it so it should be public.