### PR TITLE
feat(list): Add methods to FirebaseListObservable

### DIFF
--- a/src/utils/firebase_list_observable.spec.ts
+++ b/src/utils/firebase_list_observable.spec.ts
@@ -128,6 +128,14 @@ describe('FirebaseObservable', () => {
           .then(done, done.fail);
       });
     });
+    
+    it('should remove the whole list if no item is added', () => {
+      O.remove()
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(data.val()).toBe(null);
+        });
+    });
 
 
     it('should throw an exception if input is not supported', () => {

--- a/src/utils/firebase_list_observable.spec.ts
+++ b/src/utils/firebase_list_observable.spec.ts
@@ -30,12 +30,12 @@ describe('FirebaseObservable', () => {
   });
 
 
-  describe('add', () => {
+  describe('push', () => {
     it('should throw an exception if pushed when not subscribed', () => {
       O = new FirebaseListObservable((observer:Observer<any>) => {});
 
       expect(() => {
-        O.add('foo');
+        O.push('foo');
       }).toThrowError('No ref specified for this Observable!')
     });
 
@@ -45,19 +45,19 @@ describe('FirebaseObservable', () => {
 
       O.subscribe();
 
-      O.add(1);
+      O.push(1);
 
       expect(pushSpy).toHaveBeenCalledWith(1);
     });
 
 
     it('should accept any type of value without compilation error', () => {
-      O.add('foo');
+      O.push('foo');
     });
 
 
     it('should resolve returned thenable when successful', (done:any) => {
-      O.add('foo').then(done, done.fail);
+      O.push('foo').then(done, done.fail);
     });
   });
 
@@ -71,7 +71,7 @@ describe('FirebaseObservable', () => {
     });
 
 
-    it('should remove the item from Firebase when given the key', (done:any) => {
+    it('should remove the item from the Firebase db when given the key', (done:any) => {
       var childAddedSpy = jasmine.createSpy('childAdded');
 
       ref.on('child_added', childAddedSpy);
@@ -86,7 +86,7 @@ describe('FirebaseObservable', () => {
     });
 
 
-    it('should remove the item from Firebase when given the reference', (done:any) => {
+    it('should remove the item from the Firebase db when given the reference', (done:any) => {
       var childAddedSpy = jasmine.createSpy('childAdded');
 
       ref.on('child_added', childAddedSpy);
@@ -102,7 +102,7 @@ describe('FirebaseObservable', () => {
     });
 
 
-    it('should remove the item from Firebase when given the snapshot', (done:any) => {
+    it('should remove the item from the Firebase db when given the snapshot', (done:any) => {
       ref.on('child_added', (data:FirebaseDataSnapshot) => {
         expect(data.val()).toEqual(orphan);
         O.remove(data)
@@ -116,7 +116,7 @@ describe('FirebaseObservable', () => {
     });
 
 
-    it('should remove the item from Firebase when given the unwrapped snapshot', (done:any) => {
+    it('should remove the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
       ref.on('child_added', (data:FirebaseDataSnapshot) => {
         expect(data.val()).toEqual(orphan);
         O.remove(unwrapMapFn(data))
@@ -135,6 +135,85 @@ describe('FirebaseObservable', () => {
       expect(() => O.remove(input)).toThrowError(`FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: ${typeof input}`);
     })
   });
+  
+  describe('update', () => {
+    var orphan = { orphan: true };
+    var child:Firebase;
+
+    beforeEach(() => {
+      child = ref.push(orphan);
+    });    
+    
+    it('should update the item from the Firebase db when given the key', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child.key(), orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+    
+    it('should update the item from the Firebase db when given the reference', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child.ref(), orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });            
+
+    it('should update the item from the Firebase db when given the snapshot', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child, orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+    it('should update the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
+      const orphanChange = { changed: true }
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.update(unwrapMapFn(data), orphanChange)
+          .then(() => (<any>child).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toEqual({ 
+              orphan: true,
+              changed: true
+            });
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });        
+  
+  });
+  
 });
 
 function noop() {}

--- a/src/utils/firebase_list_observable.ts
+++ b/src/utils/firebase_list_observable.ts
@@ -40,9 +40,14 @@ export class FirebaseListObservable<T> extends Observable<T> {
     });
   }
 
-  remove(item:FirebaseOperation): Promise<void> {
+  remove(item:FirebaseOperation = null): Promise<void> {
     // TODO: remove override when typings are updated to include
     // remove() returning a promise.
+    
+    // if no item parameter is provided, remove the whole list
+    if (!item) {
+      return this._ref.remove();
+    }
     return this._checkOperationCases(item, {
       stringCase: () => this._ref.child(<string>item).remove(),
       firebaseCase: () => (<Firebase>item).remove(),

--- a/src/utils/firebase_list_observable.ts
+++ b/src/utils/firebase_list_observable.ts
@@ -3,6 +3,15 @@ import {Operator} from 'rxjs/Operator';
 import {Subscriber} from 'rxjs/Subscriber';
 import {Subscription} from 'rxjs/Subscription';
 
+export type FirebaseOperation = string | Firebase | FirebaseDataSnapshot | AFUnwrappedDataSnapshot
+
+export interface FirebaseOperationCases {
+  stringCase: () => Promise<void>;
+  firebaseCase?: () => Promise<void>;
+  snapshotCase?: () => Promise<void>;
+  unwrappedSnapshotCase?: () => Promise<void>;
+}
+
 export class FirebaseListObservable<T> extends Observable<T> {
   constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, private _ref?:Firebase) {
     super(subscribe);
@@ -15,30 +24,49 @@ export class FirebaseListObservable<T> extends Observable<T> {
     return observable;
   }
 
-  add(val:any):FirebaseWithPromise<void> {
+  push(val:any):FirebaseWithPromise<void> {
     if(!this._ref) {
       throw new Error('No ref specified for this Observable!');
     }
     return this._ref.push(val);
   }
+  
+  update(item: FirebaseOperation, value: Object): Promise<void> {
+    return this._checkOperationCases(item, {
+      stringCase: () => this._ref.child(<string>item).update(value),
+      firebaseCase: () => (<Firebase>item).update(value),
+      snapshotCase: () => (<FirebaseDataSnapshot>item).ref().update(value),
+      unwrappedSnapshotCase: () => this._ref.child((<AFUnwrappedDataSnapshot>item).$key).update(value)
+    });
+  }
 
-  remove(item:string | Firebase | FirebaseDataSnapshot | AFUnwrappedDataSnapshot): Promise<void> {
+  remove(item:FirebaseOperation): Promise<void> {
     // TODO: remove override when typings are updated to include
     // remove() returning a promise.
+    return this._checkOperationCases(item, {
+      stringCase: () => this._ref.child(<string>item).remove(),
+      firebaseCase: () => (<Firebase>item).remove(),
+      snapshotCase: () => (<FirebaseDataSnapshot>item).ref().remove(),
+      unwrappedSnapshotCase: () => this._ref.child((<AFUnwrappedDataSnapshot>item).$key).remove()
+    });
+  }
+  
+  _checkOperationCases(item: FirebaseOperation, cases: FirebaseOperationCases) : Promise<void> {
     if (typeof item === 'string') {
-      return this._ref.child(item).remove();
+      return cases.stringCase();
     } else if (item instanceof Firebase) {
       // Firebase ref
-      return item.remove();
+      return cases.firebaseCase();
     } else if (typeof (<any>item).key === 'function') {
       // Snapshot
-      return (<FirebaseDataSnapshot>item).ref().remove();
+      return cases.snapshotCase();
     } else if (typeof (<any>item).$key === 'string') {
       // Unwrapped snapshot
-      return this._ref.child((<AFUnwrappedDataSnapshot>item).$key).remove();
+      return cases.unwrappedSnapshotCase()
     }
     throw new Error(`FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: ${typeof item}`);
   }
+  
 }
 
 export interface AFUnwrappedDataSnapshot {


### PR DESCRIPTION
Closes #41. 

Thoughts @jeffbcross and @TylerEich?

Changelist:
- Renamed `add` to `push` (breaking)
- Added `update`
- Modified `remove`. If no key param provided the entire list will remove

Examples below:
```ts
export class MyApp {
 
  constructor(private _af: AngularFire) {
    const db = this._af.database;
    const pushRef = db.list('/items').push({ name: 'item 1' });
    const changedPromise = this._af.database.list('/items').update(pushRef, { changed: true});
    const removedPromise = db.list('/items').remove();
    changedPromise.then(err => console.log(err || 'No errors!'));
    removedPromise.then(err => console.log(err || 'No errors!'));
  }
  
}
```