### PR TITLE
Tweak to allow querying

### DIFF
--- a/angularfire2.js
+++ b/angularfire2.js
@@ -1,0 +1,17 @@
+System.register(['./angularfire2/angularfire2'], function(exports_1) {
+    function exportStar_1(m) {
+        var exports = {};
+        for(var n in m) {
+            if (n !== "default") exports[n] = m[n];
+        }
+        exports_1(exports);
+    }
+    return {
+        setters:[
+            function (angularfire2_1_1) {
+                exportStar_1(angularfire2_1_1);
+            }],
+        execute: function() {
+        }
+    }
+});

--- a/angularfire2/angularfire2.js
+++ b/angularfire2/angularfire2.js
@@ -1,0 +1,118 @@
+System.register(['angular2/core', './providers/auth', 'firebase', './utils/firebase_list_observable', './utils/firebase_object_observable', './utils/firebase_list_factory', './utils/firebase_object_factory', './tokens', './providers/auth_backend', './providers/firebase_sdk_auth_backend', './database/database'], function(exports_1) {
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var __metadata = (this && this.__metadata) || function (k, v) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+    };
+    var __param = (this && this.__param) || function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+    var core_1, auth_1, Firebase, firebase_list_observable_1, firebase_object_observable_1, firebase_list_factory_1, firebase_object_factory_1, tokens_1, auth_backend_1, firebase_sdk_auth_backend_1, database_1;
+    var AngularFire, COMMON_PROVIDERS, FIREBASE_PROVIDERS, defaultFirebase;
+    function getAbsUrl(root, url) {
+        if (!(/^[a-z]+:\/\/.*/.test(url))) {
+            // Provided url is relative.
+            url = root + url;
+        }
+        return url;
+    }
+    return {
+        setters:[
+            function (core_1_1) {
+                core_1 = core_1_1;
+            },
+            function (auth_1_1) {
+                auth_1 = auth_1_1;
+            },
+            function (Firebase_1) {
+                Firebase = Firebase_1;
+            },
+            function (firebase_list_observable_1_1) {
+                firebase_list_observable_1 = firebase_list_observable_1_1;
+            },
+            function (firebase_object_observable_1_1) {
+                firebase_object_observable_1 = firebase_object_observable_1_1;
+            },
+            function (firebase_list_factory_1_1) {
+                firebase_list_factory_1 = firebase_list_factory_1_1;
+            },
+            function (firebase_object_factory_1_1) {
+                firebase_object_factory_1 = firebase_object_factory_1_1;
+            },
+            function (tokens_1_1) {
+                tokens_1 = tokens_1_1;
+                exports_1({
+                    "FirebaseUrl": tokens_1_1["FirebaseUrl"],
+                    "FirebaseRef": tokens_1_1["FirebaseRef"],
+                    "FirebaseAuthConfig": tokens_1_1["FirebaseAuthConfig"]
+                });
+            },
+            function (auth_backend_1_1) {
+                auth_backend_1 = auth_backend_1_1;
+            },
+            function (firebase_sdk_auth_backend_1_1) {
+                firebase_sdk_auth_backend_1 = firebase_sdk_auth_backend_1_1;
+            },
+            function (database_1_1) {
+                database_1 = database_1_1;
+            }],
+        execute: function() {
+            AngularFire = (function () {
+                function AngularFire(fbUrl, auth, database) {
+                    this.fbUrl = fbUrl;
+                    this.auth = auth;
+                    this.database = database;
+                    this.list = database.list.bind(database);
+                    this.object = database.object.bind(database);
+                }
+                AngularFire = __decorate([
+                    core_1.Injectable(),
+                    __param(0, core_1.Inject(tokens_1.FirebaseUrl)), 
+                    __metadata('design:paramtypes', [String, auth_1.FirebaseAuth, database_1.FirebaseDatabase])
+                ], AngularFire);
+                return AngularFire;
+            })();
+            exports_1("AngularFire", AngularFire);
+            exports_1("COMMON_PROVIDERS", COMMON_PROVIDERS = [
+                core_1.provide(tokens_1.FirebaseRef, {
+                    useFactory: function (url) { return new Firebase(url); },
+                    deps: [tokens_1.FirebaseUrl] }),
+                auth_1.FirebaseAuth,
+                AngularFire,
+                database_1.FirebaseDatabase
+            ]);
+            exports_1("FIREBASE_PROVIDERS", FIREBASE_PROVIDERS = [
+                COMMON_PROVIDERS,
+                core_1.provide(auth_backend_1.AuthBackend, {
+                    useFactory: function (ref) { return new firebase_sdk_auth_backend_1.FirebaseSdkAuthBackend(ref, false); },
+                    deps: [tokens_1.FirebaseRef]
+                })
+            ]);
+            /**
+             * Used to define the default Firebase root location to be
+             * used throughout an application.
+             */
+            exports_1("defaultFirebase", defaultFirebase = function (url) {
+                return core_1.provide(tokens_1.FirebaseUrl, {
+                    useValue: url
+                });
+            });
+            exports_1("FirebaseAuth", auth_1.FirebaseAuth);
+            exports_1("FirebaseDatabase", database_1.FirebaseDatabase);
+            exports_1("FirebaseListObservable", firebase_list_observable_1.FirebaseListObservable);
+            exports_1("FirebaseObjectObservable", firebase_object_observable_1.FirebaseObjectObservable);
+            exports_1("FirebaseListFactory", firebase_list_factory_1.FirebaseListFactory);
+            exports_1("FirebaseObjectFactory", firebase_object_factory_1.FirebaseObjectFactory);
+            exports_1("firebaseAuthConfig", auth_1.firebaseAuthConfig);
+            exports_1("AuthMethods", auth_backend_1.AuthMethods);
+            exports_1("AuthProviders", auth_backend_1.AuthProviders);
+            exports_1("default",{
+                providers: FIREBASE_PROVIDERS
+            });
+        }
+    }
+});

--- a/angularfire2/angularfire2.spec.ts
+++ b/angularfire2/angularfire2.spec.ts
@@ -1,0 +1,161 @@
+import {
+  describe,
+  ddescribe,
+  it,
+  iit,
+  beforeEach,
+  beforeEachProviders,
+  expect,
+  inject,
+  injectAsync
+} from 'angular2/testing';
+import {Injector, provide, Provider} from 'angular2/core';
+import {
+  AngularFire,
+  FirebaseObjectObservable,
+  FIREBASE_PROVIDERS,
+  FirebaseAuth,
+  FirebaseUrl,
+  FirebaseRef,
+  defaultFirebase
+} from './angularfire2';
+import {Subscription} from 'rxjs';
+import 'rxjs/add/operator/toPromise';
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/delay';
+
+// Only use this URL for angularfire2.spec.ts
+const localServerUrl = 'https://angularfire2.firebaseio-demo.com/';
+
+describe('angularfire', () => {
+  var subscription:Subscription;
+  const questionsRef = new Firebase(localServerUrl).child('questions');
+  const listOfQuestionsRef = new Firebase(localServerUrl).child('list-of-questions');
+
+  afterEach((done:any) => {
+    // Clear out the Firebase to prevent leaks between tests
+    (new Firebase(localServerUrl)).remove(done);
+    if(subscription && !subscription.isUnsubscribed) {
+      subscription.unsubscribe();
+    }
+  });
+
+
+  it('should be injectable via FIREBASE_PROVIDERS', () => {
+    var injector = Injector.resolveAndCreate([FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+    expect(injector.get(AngularFire)).toBeAnInstanceOf(AngularFire);
+  });
+
+  describe('.list()', () => {
+    var af:AngularFire;
+    beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+    beforeEach(inject([AngularFire], (_af:AngularFire) => {
+      af = _af;
+    }));
+
+
+    it('should accept an absolute url', () => {
+      expect((<any>af.list(localServerUrl))._ref.toString()).toBe(localServerUrl);
+    });
+
+
+    it('should return an observable of the path', (done:any) => {
+      var questions = af.list(`/questions`);
+      questionsRef.push({pathObservable:true}, () => {
+        subscription = questions
+          .take(1)
+          .do((data:any) => {
+            expect(data.length).toBe(1);
+            expect(data[0].pathObservable).toBe(true);
+          })
+          .subscribe(done, done.fail);
+      });
+    });
+
+
+    it('should preserve snapshots in the list if preserveSnapshot option specified', (done:any) => {
+      var questions = af.list(`list-of-questions`, {preserveSnapshot: true});
+      listOfQuestionsRef.push('hello', () => {
+        subscription = questions
+          .take(1)
+          .do((data:any) => {
+            expect(data[0].val()).toEqual('hello');
+          })
+          .subscribe(done, done.fail);
+      });
+    });
+  });
+
+
+  describe('.object()', () => {
+    var observable:FirebaseObjectObservable<any>;
+    var af:AngularFire;
+
+    beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+    beforeEach(inject([AngularFire], (_af:AngularFire) => {
+      observable = _af.object(`/list-of-questions/1`)
+      af = _af;
+    }));
+
+
+    it('should accept an absolute url', () => {
+      expect((<any>af.object(localServerUrl))._ref.toString()).toBe(localServerUrl);
+    });
+
+
+    it('should return an observable of the path', injectAsync([AngularFire], (af:AngularFire) => {
+      return (<any>observable)._ref.set({title: 'how to firebase?'})
+        .then(() => observable.take(1).toPromise())
+        .then((data:any) => {
+          expect(data).toEqual({title: 'how to firebase?'});
+        });
+    }));
+
+
+    it('should preserve snapshot if preserveSnapshot option specified', injectAsync([AngularFire], (af:AngularFire) => {
+      observable = af.object(`list-of-questions/`, {preserveSnapshot: true});
+      return (<any>observable)._ref.set({title: 'how to firebase?'})
+        .then(() => observable.take(1).toPromise())
+        .then((data:any) => {
+          expect(data.val()).toEqual({title: 'how to firebase?'});
+        });
+    }));
+  });
+
+
+  describe('.auth', () => {
+    beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+
+    it('should be an instance of AuthService', inject([AngularFire], (af:AngularFire) => {
+      expect(af.auth).toBeAnInstanceOf(FirebaseAuth);
+    }));
+  });
+
+
+  describe('FIREBASE_REF', () => {
+    it('should provide a FirebaseRef for the FIREBASE_REF binding', () => {
+      var injector = Injector.resolveAndCreate([
+        provide(FirebaseUrl, {
+          useValue: localServerUrl
+        }),
+        FIREBASE_PROVIDERS
+      ]);
+      expect(typeof injector.get(FirebaseRef).on).toBe('function');
+    })
+  });
+
+  describe('defaultFirebase', () => {
+    it('should create a provider', () => {
+      const provider = defaultFirebase(localServerUrl);
+      expect(provider).toBeAnInstanceOf(Provider);
+    });
+
+
+    it('should inject a FIR reference', () => {
+      const injector = Injector.resolveAndCreate([defaultFirebase(localServerUrl), FIREBASE_PROVIDERS]);
+      expect(injector.get(FirebaseRef).toString()).toBe(localServerUrl);
+    });
+  });
+
+});

--- a/angularfire2/angularfire2.ts
+++ b/angularfire2/angularfire2.ts
@@ -1,0 +1,89 @@
+import {APP_INITIALIZER, Inject, Injectable, OpaqueToken, provide, Provider} from 'angular2/core';
+import {FirebaseAuth, firebaseAuthConfig} from './providers/auth';
+import * as Firebase from 'firebase';
+import {FirebaseListObservable} from './utils/firebase_list_observable';
+import {FirebaseObjectObservable} from './utils/firebase_object_observable';
+import {FirebaseListFactory, FirebaseListFactoryOpts} from './utils/firebase_list_factory';
+import {
+  FirebaseObjectFactoryOpts,
+  FirebaseObjectFactory
+} from './utils/firebase_object_factory';
+import {FirebaseUrl, FirebaseRef} from './tokens';
+import {
+  AuthBackend,
+  AuthMethods,
+  AuthProviders,
+  FirebaseAuthState
+} from './providers/auth_backend';
+import {FirebaseSdkAuthBackend} from './providers/firebase_sdk_auth_backend';
+import {FirebaseDatabase} from './database/database';
+
+@Injectable()
+export class AngularFire {
+  list: (url:string, opts?:FirebaseListFactoryOpts) => FirebaseListObservable<any[]>;
+  object: (url: string, opts?:FirebaseObjectFactoryOpts) => FirebaseObjectObservable<any>;
+  constructor(
+    @Inject(FirebaseUrl) private fbUrl:string,
+    public auth:FirebaseAuth,
+    public database: FirebaseDatabase) {
+      this.list = database.list.bind(database);
+      this.object = database.object.bind(database);
+  }
+
+}
+
+function getAbsUrl (root:string, url:string) {
+  if (!(/^[a-z]+:\/\/.*/.test(url))) {
+    // Provided url is relative.
+    url = root + url;
+  }
+  return url;
+}
+
+export const COMMON_PROVIDERS: any[] = [
+  provide(FirebaseRef, {
+    useFactory: (url:string) => new Firebase(url),
+    deps: [FirebaseUrl]}),
+  FirebaseAuth,
+  AngularFire,
+  FirebaseDatabase
+];
+
+export const FIREBASE_PROVIDERS:any[] = [
+  COMMON_PROVIDERS,
+  provide(AuthBackend, {
+    useFactory: (ref: Firebase) => new FirebaseSdkAuthBackend(ref, false),
+    deps: [FirebaseRef]
+  })
+];
+
+/**
+ * Used to define the default Firebase root location to be
+ * used throughout an application.
+ */
+export const defaultFirebase = (url: string): Provider => {
+  return provide(FirebaseUrl, {
+    useValue: url
+  });
+};
+
+export {
+  FirebaseAuth,
+  FirebaseDatabase,
+  FirebaseListObservable,
+  FirebaseObjectObservable,
+  FirebaseListFactory,
+  FirebaseObjectFactory,
+  firebaseAuthConfig,
+  FirebaseAuthState,
+  AuthMethods,
+  AuthProviders
+}
+
+export {FirebaseUrl, FirebaseRef, FirebaseAuthConfig} from './tokens';
+
+// Helps Angular-CLI automatically add providers
+export default {
+  providers: FIREBASE_PROVIDERS
+}
+

--- a/angularfire2/angularfire2_worker_app.ts
+++ b/angularfire2/angularfire2_worker_app.ts
@@ -1,0 +1,9 @@
+import {provide} from 'angular2/core';
+import {COMMON_PROVIDERS} from './angularfire2';
+import {AuthBackend} from './providers/auth_backend';
+import {WebWorkerFirebaseAuth} from './providers/web_workers/worker/auth';
+
+export const WORKER_APP_FIREBASE_PROVIDERS: any[] = [
+  COMMON_PROVIDERS,
+  provide(AuthBackend, {useClass: WebWorkerFirebaseAuth})
+];

--- a/angularfire2/angularfire2_worker_render.ts
+++ b/angularfire2/angularfire2_worker_render.ts
@@ -1,0 +1,17 @@
+import {provide} from 'angular2/core';
+import {COMMON_PROVIDERS} from './angularfire2';
+import {FirebaseSdkAuthBackend} from './providers/firebase_sdk_auth_backend';
+import {WebWorkerFirebaseAuth} from './providers/web_workers/worker/auth';
+import {FirebaseRef} from './tokens';
+import {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';
+
+export const WORKER_RENDER_FIREBASE_PROVIDERS: any[] = [
+  COMMON_PROVIDERS,
+  provide(FirebaseSdkAuthBackend, {
+    useFactory: (ref: Firebase) => new FirebaseSdkAuthBackend(ref, true),
+    deps: [FirebaseRef]
+  }),
+  MessageBasedFirebaseAuth
+];
+
+export {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';

--- a/angularfire2/database/database.js
+++ b/angularfire2/database/database.js
@@ -1,0 +1,69 @@
+System.register(['angular2/core', '../tokens', '../utils/firebase_list_factory', '../utils/firebase_object_factory', '../utils/utils'], function(exports_1) {
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var __metadata = (this && this.__metadata) || function (k, v) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+    };
+    var __param = (this && this.__param) || function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+    var core_1, tokens_1, firebase_list_factory_1, firebase_object_factory_1, utils;
+    var FirebaseDatabase;
+    function getAbsUrl(root, url) {
+        if (!(/^[a-z]+:\/\/.*/.test(url))) {
+            // Provided url is relative.
+            url = root + url;
+        }
+        return url;
+    }
+    return {
+        setters:[
+            function (core_1_1) {
+                core_1 = core_1_1;
+            },
+            function (tokens_1_1) {
+                tokens_1 = tokens_1_1;
+            },
+            function (firebase_list_factory_1_1) {
+                firebase_list_factory_1 = firebase_list_factory_1_1;
+            },
+            function (firebase_object_factory_1_1) {
+                firebase_object_factory_1 = firebase_object_factory_1_1;
+            },
+            function (utils_1) {
+                utils = utils_1;
+            }],
+        execute: function() {
+            FirebaseDatabase = (function () {
+                function FirebaseDatabase(fbUrl) {
+                    this.fbUrl = fbUrl;
+                }
+                FirebaseDatabase.prototype.list = function (urlOrRef, opts) {
+                    var _this = this;
+                    return utils.checkForUrlOrFirebaseRef(urlOrRef, {
+                        isUrl: function () { return firebase_list_factory_1.FirebaseListFactory(getAbsUrl(_this.fbUrl, urlOrRef), opts); },
+                        isRef: function () { return firebase_list_factory_1.FirebaseListFactory(urlOrRef); }
+                    });
+                };
+                FirebaseDatabase.prototype.object = function (urlOrRef, opts) {
+                    var _this = this;
+                    return utils.checkForUrlOrFirebaseRef(urlOrRef, {
+                        isUrl: function () { return firebase_object_factory_1.FirebaseObjectFactory(getAbsUrl(_this.fbUrl, urlOrRef), opts); },
+                        isRef: function () { return firebase_object_factory_1.FirebaseObjectFactory(urlOrRef); }
+                    });
+                };
+                FirebaseDatabase = __decorate([
+                    core_1.Injectable(),
+                    __param(0, core_1.Inject(tokens_1.FirebaseUrl)), 
+                    __metadata('design:paramtypes', [String])
+                ], FirebaseDatabase);
+                return FirebaseDatabase;
+            })();
+            exports_1("FirebaseDatabase", FirebaseDatabase);
+        }
+    }
+});

--- a/angularfire2/database/database.ts
+++ b/angularfire2/database/database.ts
@@ -1,0 +1,32 @@
+import {Inject, Injectable} from 'angular2/core';
+import {FirebaseUrl} from '../tokens';
+import {FirebaseListObservable} from '../utils/firebase_list_observable';
+import {FirebaseObjectObservable} from '../utils/firebase_object_observable';
+import {FirebaseListFactory, FirebaseListFactoryOpts} from '../utils/firebase_list_factory';
+import {FirebaseObjectFactoryOpts, FirebaseObjectFactory} from '../utils/firebase_object_factory';
+import * as utils from '../utils/utils'
+
+@Injectable()
+export class FirebaseDatabase {
+  constructor(@Inject(FirebaseUrl) private fbUrl:string) {}
+  list (urlOrRef:string | Firebase | FirebaseQuery, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
+    return utils.checkForUrlOrFirebaseRef(urlOrRef, {
+      isUrl: () => FirebaseListFactory(getAbsUrl(this.fbUrl, <string>urlOrRef), opts),
+      isRef: () => FirebaseListFactory(<Firebase>urlOrRef)
+    });
+  }
+  object(urlOrRef: string | Firebase | FirebaseQuery, opts?:FirebaseObjectFactoryOpts):FirebaseObjectObservable<any> {
+    return utils.checkForUrlOrFirebaseRef(urlOrRef, {
+      isUrl: () => FirebaseObjectFactory(getAbsUrl(this.fbUrl, <string>urlOrRef), opts),
+      isRef: () => FirebaseObjectFactory(urlOrRef)
+    });
+  }
+}
+
+function getAbsUrl (root:string, url:string) {
+  if (!(/^[a-z]+:\/\/.*/.test(url))) {
+    // Provided url is relative.
+    url = root + url;
+  }
+  return url;
+}

--- a/angularfire2/providers/auth.js
+++ b/angularfire2/providers/auth.js
@@ -1,0 +1,158 @@
+System.register(['angular2/core', 'rxjs/subject/ReplaySubject', '../tokens', '../utils/utils', './auth_backend'], function(exports_1) {
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var __metadata = (this && this.__metadata) || function (k, v) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+    };
+    var __param = (this && this.__param) || function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+    var core_1, ReplaySubject_1, tokens_1, utils_1, auth_backend_1;
+    var kBufferSize, firebaseAuthConfig, FirebaseAuth;
+    return {
+        setters:[
+            function (core_1_1) {
+                core_1 = core_1_1;
+            },
+            function (ReplaySubject_1_1) {
+                ReplaySubject_1 = ReplaySubject_1_1;
+            },
+            function (tokens_1_1) {
+                tokens_1 = tokens_1_1;
+            },
+            function (utils_1_1) {
+                utils_1 = utils_1_1;
+            },
+            function (auth_backend_1_1) {
+                auth_backend_1 = auth_backend_1_1;
+            }],
+        execute: function() {
+            kBufferSize = 1;
+            exports_1("firebaseAuthConfig", firebaseAuthConfig = function (config) {
+                return core_1.provide(tokens_1.FirebaseAuthConfig, {
+                    useValue: config
+                });
+            });
+            FirebaseAuth = (function (_super) {
+                __extends(FirebaseAuth, _super);
+                function FirebaseAuth(_authBackend, _config) {
+                    var _this = this;
+                    _super.call(this, kBufferSize);
+                    this._authBackend = _authBackend;
+                    this._config = _config;
+                    this._authBackend.onAuth(function (authData) { return _this._emitAuthData(authData); });
+                }
+                FirebaseAuth.prototype.login = function (obj1, obj2) {
+                    var config = null;
+                    var credentials = null;
+                    if (arguments.length > 2) {
+                        return this._reject('Login only accepts a maximum of two arguments.');
+                    }
+                    else if (arguments.length == 2) {
+                        credentials = obj1;
+                        config = obj2;
+                    }
+                    else if (arguments.length == 1) {
+                        // Check if obj1 is password credentials
+                        if (obj1.password && obj1.email) {
+                            credentials = obj1;
+                            config = {};
+                        }
+                        else {
+                            config = obj1;
+                        }
+                    }
+                    config = this._mergeConfigs(config);
+                    if (!utils_1.isPresent(config.method)) {
+                        return this._reject('You must provide a login method');
+                    }
+                    var providerMethods = [auth_backend_1.AuthMethods.Popup, auth_backend_1.AuthMethods.Redirect, auth_backend_1.AuthMethods.OAuthToken];
+                    if (providerMethods.indexOf(config.method) != -1) {
+                        if (!utils_1.isPresent(config.provider)) {
+                            return this._reject('You must include a provider to use this auth method.');
+                        }
+                    }
+                    var credentialsMethods = [auth_backend_1.AuthMethods.Password, auth_backend_1.AuthMethods.OAuthToken, auth_backend_1.AuthMethods.CustomToken];
+                    if (credentialsMethods.indexOf(config.method) != -1) {
+                        if (!credentials) {
+                            return this._reject('You must include credentials to use this auth method.');
+                        }
+                    }
+                    switch (config.method) {
+                        case auth_backend_1.AuthMethods.Popup:
+                            return this._authBackend.authWithOAuthPopup(config.provider, this._scrubConfig(config));
+                        case auth_backend_1.AuthMethods.Redirect:
+                            return this._authBackend.authWithOAuthRedirect(config.provider, this._scrubConfig(config));
+                        case auth_backend_1.AuthMethods.Anonymous:
+                            return this._authBackend.authAnonymously(this._scrubConfig(config));
+                        case auth_backend_1.AuthMethods.Password:
+                            return this._authBackend.authWithPassword(credentials, this._scrubConfig(config, false));
+                        case auth_backend_1.AuthMethods.OAuthToken:
+                            return this._authBackend.authWithOAuthToken(config.provider, credentials, this._scrubConfig(config));
+                        case auth_backend_1.AuthMethods.CustomToken:
+                            return this._authBackend.authWithCustomToken(credentials.token, this._scrubConfig(config, false));
+                    }
+                };
+                FirebaseAuth.prototype.logout = function () {
+                    if (this._authBackend.getAuth() !== null) {
+                        this._authBackend.unauth();
+                    }
+                };
+                FirebaseAuth.prototype.getAuth = function () {
+                    return this._authBackend.getAuth();
+                };
+                FirebaseAuth.prototype.createUser = function (credentials) {
+                    return this._authBackend.createUser(credentials);
+                };
+                /**
+                 * Merges the config object that is passed in with the configuration
+                 * provided through DI. Giving precendence to the one that was passed.
+                 */
+                FirebaseAuth.prototype._mergeConfigs = function (config) {
+                    if (this._config == null)
+                        return config;
+                    return Object.assign({}, this._config, config);
+                };
+                FirebaseAuth.prototype._reject = function (msg) {
+                    return new Promise(function (res, rej) {
+                        return rej(msg);
+                    });
+                };
+                FirebaseAuth.prototype._scrubConfig = function (config, scrubProvider) {
+                    if (scrubProvider === void 0) { scrubProvider = true; }
+                    var scrubbed = Object.assign({}, config);
+                    if (scrubProvider) {
+                        delete scrubbed.provider;
+                    }
+                    delete scrubbed.method;
+                    return scrubbed;
+                };
+                FirebaseAuth.prototype._emitAuthData = function (authData) {
+                    if (authData == null) {
+                        this.next(null);
+                    }
+                    else {
+                        this.next(auth_backend_1.authDataToAuthState(authData));
+                    }
+                };
+                FirebaseAuth = __decorate([
+                    core_1.Injectable(),
+                    __param(1, core_1.Optional()),
+                    __param(1, core_1.Inject(tokens_1.FirebaseAuthConfig)), 
+                    __metadata('design:paramtypes', [auth_backend_1.AuthBackend, Object])
+                ], FirebaseAuth);
+                return FirebaseAuth;
+            })(ReplaySubject_1.ReplaySubject);
+            exports_1("FirebaseAuth", FirebaseAuth);
+        }
+    }
+});

--- a/angularfire2/providers/auth.spec.ts
+++ b/angularfire2/providers/auth.spec.ts
@@ -1,0 +1,509 @@
+/// <reference path="../../manual_typings/manual_typings.d.ts" />
+
+import {expect, describe, it, iit, beforeEach} from 'angular2/testing';
+import {Injector, provide, Provider} from 'angular2/core';
+import {Observable} from 'rxjs/Observable'
+import {
+  FIREBASE_PROVIDERS,
+  FirebaseRef,
+  FirebaseUrl,
+  FirebaseAuth,
+  AuthMethods,
+  FirebaseAuthState,
+  firebaseAuthConfig,
+  AuthProviders
+} from '../angularfire2';
+import {AuthBackend} from './auth_backend';
+import {FirebaseSdkAuthBackend} from './firebase_sdk_auth_backend';
+import * as Firebase from 'firebase';
+import * as mockPromises from 'mock-promises';
+
+describe('FirebaseAuth', () => {
+  let injector: Injector = null;
+  let ref: Firebase = null;
+  let authData: any = null;
+  let authCb: any = null;
+  let backend: AuthBackend = null;
+
+  const providerMetadata = {
+    accessToken: 'accessToken',
+    displayName: 'github User',
+    username: 'githubUsername',
+    id: '12345',
+    expires: 0
+  }
+
+  const authObj = {
+    token: 'key'
+  }
+
+  const authState = {
+    provider: 'github',
+    uid: 'github:12345',
+    github: providerMetadata,
+    auth: authObj,
+    expires: 0
+  };
+
+  const AngularFireAuthState = {
+    provider: AuthProviders.Github,
+    uid: 'github:12345',
+    github: providerMetadata,
+    auth: authObj,
+    expires: 0
+  }
+
+  beforeEach(() => {
+    authData = null;
+    authCb = null;
+    injector = Injector.resolveAndCreate([
+      provide(FirebaseUrl, {
+        useValue: 'https://angularfire2-auth.firebaseio-demo.com/'
+      }),
+      FIREBASE_PROVIDERS
+    ]);
+
+  });
+
+
+  it('should be an observable', () => {
+    expect(injector.get(FirebaseAuth)).toBeAnInstanceOf(Observable);
+  })
+
+  describe('AuthState', () => {
+
+    beforeEach(() => {
+      ref = injector.get(FirebaseRef);
+      spyOn(ref, 'onAuth').and.callFake((fn: (a: any) => void) => {
+        authCb = fn;
+        if (authCb !== null) {
+          authCb(authData);
+        }
+      });
+      backend = new FirebaseSdkAuthBackend(ref);
+    });
+    function updateAuthState(_authData: any): void {
+      authData = _authData;
+      if (authCb !== null) {
+        authCb(authData);
+      }
+    }
+
+    it('should synchronously load firebase auth data', () => {
+      updateAuthState(authState);
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(AngularFireAuthState);
+    });
+
+    it('should be null if user is not authed', () => {
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should emit auth updates', (done: () => void) => {
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(null);
+      setTimeout(() => {
+        nextSpy.calls.reset();
+
+        updateAuthState(authState);
+        expect(nextSpy).toHaveBeenCalledWith(AngularFireAuthState);
+        done();
+      }, 1);
+    });
+  });
+
+  function getArgIndex(callbackName: string): number {
+    //In the firebase API, the completion callback is the second argument for all but a few functions.
+    switch (callbackName) {
+      case 'authAnonymously':
+      case 'onAuth':
+        return 0;
+      case 'authWithOAuthToken':
+        return 2;
+      default:
+        return 1;
+    }
+  }
+
+  // calls the firebase callback
+  function callback(callbackName: string, callIndex?: number): Function {
+    callIndex = callIndex || 0; //assume the first call.
+    var argIndex = getArgIndex(callbackName);
+    return (<any>ref)[callbackName].calls.argsFor(callIndex)[argIndex];
+  }
+
+  describe('firebaseAuthConfig', () => {
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+    });
+
+    it('should return a provider', () => {
+      expect(firebaseAuthConfig({ method: AuthMethods.Password })).toBeAnInstanceOf(Provider);
+    });
+
+    it('should use config in login', () => {
+      let config = {
+        method: AuthMethods.Anonymous
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login();
+      expect(ref.authAnonymously).toHaveBeenCalled();
+    });
+
+    it('should pass options on to login method', () => {
+      let config = {
+        method: AuthMethods.Anonymous,
+        remember: 'default'
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login();
+      expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
+    });
+
+    it('should be overridden by login\'s arguments', () => {
+      let config = {
+        method: AuthMethods.Anonymous
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login({
+        method: AuthMethods.Popup,
+        provider: AuthProviders.Google
+      });
+      expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('google', jasmine.any(Function), {});
+    });
+
+    it('should be merged with login\'s arguments', () => {
+      let config = {
+        method: AuthMethods.Popup,
+        provider: AuthProviders.Google,
+        scope: ['email']
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login({
+        provider: AuthProviders.Github
+      });
+      expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('github', jasmine.any(Function), {
+        scope: ['email']
+      });
+    });
+  });
+
+  describe('createUser', () => {
+    let auth: FirebaseAuth = null;
+    let credentials = { email: 'myname', password: 'password' };
+
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+      auth = new FirebaseAuth(backend);
+    });
+
+    it('should call createUser on a db reference', () => {
+      auth.createUser(credentials);
+      expect(ref.createUser)
+        .toHaveBeenCalledWith(credentials, jasmine.any(Function));
+    });
+
+  });
+
+  describe('login', () => {
+    let auth: FirebaseAuth = null;
+
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+      auth = new FirebaseAuth(backend);
+    });
+
+    it('should reject if password is used without credentials', (done: any) => {
+      let config = {
+        method: AuthMethods.Password
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    it('should reject if custom token is used without credentials', (done: any) => {
+      let config = {
+        method: AuthMethods.CustomToken
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);;
+    });
+
+    it('should reject if oauth token is used without credentials', (done: any) => {
+      let config = {
+        method: AuthMethods.OAuthToken
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    it('should reject if popup is used without a provider', (done: any) => {
+      let config = {
+        method: AuthMethods.Popup
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    it('should reject if redirect is used without a provider', (done: any) => {
+      let config = {
+        method: AuthMethods.Redirect
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    describe('authWithCustomToken', () => {
+      let options = {
+        remember: 'default',
+        method: AuthMethods.CustomToken
+      };
+      let credentials = {
+        token: 'myToken'
+      };
+
+      it('passes custom token to underlying method', () => {
+        auth.login(credentials, options);
+        expect(ref.authWithCustomToken)
+          .toHaveBeenCalledWith('myToken', jasmine.any(Function), { remember: 'default' });
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(credentials, options).then(done.fail, done);
+        callback('authWithCustomToken')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(credentials, options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithCustomToken')(null, authState);
+      });
+    });
+
+    describe('authAnonymously', () => {
+      let options = {
+        remember: 'default',
+        method: AuthMethods.Anonymous
+      };
+      it('passes options object to underlying method', () => {
+        auth.login(options);
+        expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(options).then(done.fail, done);
+        callback('authAnonymously')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authAnonymously')(null, authState);
+      });
+    });
+
+    describe('authWithPassword', () => {
+      let options = { remember: 'default', method: AuthMethods.Password };
+      let credentials = { email: 'myname', password: 'password' };
+
+      it('should login with password credentials', () => {
+        let config = {
+          method: AuthMethods.Password,
+          provider: AuthProviders.Password
+        };
+        const credentials = {
+          email: 'david@fire.com',
+          password: 'supersecretpassword'
+        };
+        let auth = new FirebaseAuth(backend, config);
+        auth.login(credentials);
+        expect(ref.authWithPassword).toHaveBeenCalledWith(credentials,
+          jasmine.any(Function),
+          { provider: config.provider });
+      });
+
+      it('passes options and credentials object to underlying method', () => {
+        auth.login(credentials, options);
+        expect(ref.authWithPassword).toHaveBeenCalledWith(
+          credentials,
+          jasmine.any(Function),
+          { remember: options.remember }
+        );
+      });
+
+      it('will revoke the promise if authentication fails', (done: any) => {
+        auth.login(credentials, options).then(done.fail, done);
+        callback('authWithPassword')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(credentials, options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithPassword')(null, authState);
+      });
+    });
+
+    describe('authWithOAuthPopup', function() {
+      let options = {
+        method: AuthMethods.Popup,
+        provider: AuthProviders.Github
+      };
+      it('passes provider and options object to underlying method', () => {
+        let customOptions = Object.assign({}, options);
+        customOptions.scope = ['email'];
+        auth.login(customOptions);
+        expect(ref.authWithOAuthPopup).toHaveBeenCalledWith(
+          'github',
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(options).then(done.fail, done);
+        callback('authWithOAuthPopup')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithOAuthPopup')(null, authState);
+      });
+    });
+
+    describe('authWithOAuthRedirect', () => {
+      const options = {
+        method: AuthMethods.Redirect,
+        provider: AuthProviders.Github
+      };
+      it('passes provider and options object to underlying method', () => {
+        let customOptions = Object.assign({}, options);
+        customOptions.scope = ['email'];
+        auth.login(customOptions);
+        expect(ref.authWithOAuthRedirect).toHaveBeenCalledWith(
+          'github',
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(options).then(done.fail, done);
+        callback('authWithOAuthRedirect')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithOAuthRedirect')(null, authState);
+      });
+    });
+
+    describe('authWithOAuthToken', () => {
+      const options = {
+        method: AuthMethods.OAuthToken,
+        provider: AuthProviders.Github,
+        scope: ['email']
+      };
+      const token = 'GITHUB_TOKEN';
+      const credentials = {
+        token: token
+      };
+      it('passes provider, token, and options object to underlying method', () => {
+        auth.login(credentials, options);
+        expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
+          'github',
+          token,
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('passes provider, OAuth credentials, and options object to underlying method', () => {
+        let customOptions = Object.assign({}, options);
+        customOptions.provider = AuthProviders.Twitter;
+        let twitterCredentials = {
+          "user_id": "<USER-ID>",
+          "oauth_token": "<ACCESS-TOKEN>",
+          "oauth_token_secret": "<ACCESS-TOKEN-SECRET>"
+        };
+        auth.login(twitterCredentials, customOptions);
+        expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
+          'twitter',
+          twitterCredentials,
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        let creds = {
+          token: ''
+        };
+        auth.login(creds, options).then(done.fail, done);
+        callback('authWithOAuthToken')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(credentials, options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithOAuthToken')(null, authState);
+      });
+    });
+
+
+    describe('unauth()', () => {
+      it('will call unauth() on the backing ref if logged in', () => {
+        (<any>ref).getAuth.and.returnValue({ provider: 'twitter' }); auth.logout();
+        expect(ref.unauth).toHaveBeenCalled();
+      });
+
+      it('will NOT call unauth() on the backing ref if NOT logged in', () => {
+        (<any>ref).getAuth.and.returnValue(null);
+        auth.logout();
+        expect(ref.unauth).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+

--- a/angularfire2/providers/auth.ts
+++ b/angularfire2/providers/auth.ts
@@ -1,0 +1,141 @@
+import {Provider, Inject, provide, Injectable, Optional} from 'angular2/core';
+import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {FirebaseRef, FirebaseAuthConfig} from '../tokens';
+import {isPresent} from '../utils/utils';
+import * as utils from '../utils/utils';
+import {
+  AuthBackend,
+  AuthProviders,
+  AuthMethods,
+  OAuthCredentials,
+  OAuth1Credentials,
+  OAuth2Credentials,
+  AuthCredentials,
+  FirebaseAuthState,
+  AuthConfiguration,
+  FirebaseAuthDataAllProviders,
+  authDataToAuthState
+} from './auth_backend';
+
+const kBufferSize = 1;
+
+export const firebaseAuthConfig = (config: AuthConfiguration): Provider => {
+  return provide(FirebaseAuthConfig, {
+    useValue: config
+  });
+};
+
+@Injectable()
+export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
+  constructor(private _authBackend: AuthBackend,
+    @Optional() @Inject(FirebaseAuthConfig) private _config?: AuthConfiguration) {
+    super(kBufferSize);
+
+    this._authBackend.onAuth((authData) => this._emitAuthData(authData));
+  }
+
+  public login(config?: AuthConfiguration): Promise<FirebaseAuthState>;
+  public login(credentials?: FirebaseCredentials): Promise<FirebaseAuthState>;
+  public login(credentials: AuthCredentials, config?: AuthConfiguration): Promise<FirebaseAuthState>;
+  public login(obj1?: any, obj2?: AuthConfiguration): Promise<FirebaseAuthState> {
+    let config: AuthConfiguration = null;
+    let credentials: AuthCredentials = null;
+    if (arguments.length > 2) {
+      return this._reject('Login only accepts a maximum of two arguments.');
+    } else if (arguments.length == 2) {
+      credentials = obj1;
+      config = obj2;
+    } else if (arguments.length == 1) {
+      // Check if obj1 is password credentials
+      if (obj1.password && obj1.email) {
+        credentials = obj1;
+        config = {};
+      } else {
+        config = obj1;
+      }
+    }
+    config = this._mergeConfigs(config);
+
+    if (!isPresent(config.method)) {
+      return this._reject('You must provide a login method');
+    }
+    let providerMethods = [AuthMethods.Popup, AuthMethods.Redirect, AuthMethods.OAuthToken];
+    if (providerMethods.indexOf(config.method) != -1) {
+      if (!isPresent(config.provider)) {
+        return this._reject('You must include a provider to use this auth method.');
+      }
+    }
+    let credentialsMethods = [AuthMethods.Password, AuthMethods.OAuthToken, AuthMethods.CustomToken];
+    if (credentialsMethods.indexOf(config.method) != -1) {
+      if (!credentials) {
+        return this._reject('You must include credentials to use this auth method.');
+      }
+    }
+
+    switch (config.method) {
+      case AuthMethods.Popup:
+        return this._authBackend.authWithOAuthPopup(config.provider, this._scrubConfig(config));
+      case AuthMethods.Redirect:
+        return this._authBackend.authWithOAuthRedirect(config.provider, this._scrubConfig(config));
+      case AuthMethods.Anonymous:
+        return this._authBackend.authAnonymously(this._scrubConfig(config));
+      case AuthMethods.Password:
+        return this._authBackend.authWithPassword(<FirebaseCredentials>credentials, this._scrubConfig(config, false));
+      case AuthMethods.OAuthToken:
+        return this._authBackend.authWithOAuthToken(config.provider, <OAuthCredentials>credentials,
+          this._scrubConfig(config));
+      case AuthMethods.CustomToken:
+        return this._authBackend.authWithCustomToken((<OAuth2Credentials>credentials).token,
+          this._scrubConfig(config, false));
+    }
+  }
+
+  public logout(): void {
+    if (this._authBackend.getAuth() !== null) {
+      this._authBackend.unauth();
+    }
+  }
+
+  public getAuth(): FirebaseAuthData {
+    return this._authBackend.getAuth();
+  }
+
+  public createUser(credentials: FirebaseCredentials): Promise<FirebaseAuthData> {
+    return this._authBackend.createUser(credentials);
+  }
+
+  /**
+   * Merges the config object that is passed in with the configuration
+   * provided through DI. Giving precendence to the one that was passed.
+   */
+  private _mergeConfigs(config: AuthConfiguration): AuthConfiguration {
+    if (this._config == null)
+      return config;
+
+    return Object.assign({}, this._config, config);
+  }
+
+  private _reject(msg: string): Promise<FirebaseAuthState> {
+    return new Promise((res, rej) => {
+      return rej(msg);
+    });
+  }
+
+  private _scrubConfig(config: AuthConfiguration, scrubProvider = true): any {
+    let scrubbed = Object.assign({}, config);
+    if (scrubProvider) {
+      delete scrubbed.provider;
+    }
+    delete scrubbed.method;
+    return scrubbed;
+  }
+
+
+  private _emitAuthData(authData: FirebaseAuthDataAllProviders): void {
+    if (authData == null) {
+      this.next(null);
+    } else {
+      this.next(authDataToAuthState(authData));
+    }
+  }
+}

--- a/angularfire2/providers/auth_backend.js
+++ b/angularfire2/providers/auth_backend.js
@@ -1,0 +1,72 @@
+System.register([], function(exports_1) {
+    var AuthBackend, AuthProviders, AuthMethods;
+    function authDataToAuthState(authData) {
+        var auth = authData.auth, uid = authData.uid, provider = authData.provider, github = authData.github, twitter = authData.twitter, facebook = authData.facebook, google = authData.google, password = authData.password, anonymous = authData.anonymous;
+        var authState = { auth: auth, uid: uid, expires: authData.expires, provider: null };
+        switch (provider) {
+            case 'github':
+                authState.github = github;
+                authState.provider = AuthProviders.Github;
+                break;
+            case 'twitter':
+                authState.twitter = twitter;
+                authState.provider = AuthProviders.Twitter;
+                break;
+            case 'facebook':
+                authState.facebook = facebook;
+                authState.provider = AuthProviders.Facebook;
+                break;
+            case 'google':
+                authState.google = google;
+                authState.provider = AuthProviders.Google;
+                break;
+            case 'password':
+                authState.password = password;
+                authState.provider = AuthProviders.Password;
+                break;
+            case 'anonymous':
+                authState.anonymous = anonymous;
+                authState.provider = AuthProviders.Anonymous;
+                break;
+            case 'custom':
+                authState.provider = AuthProviders.Custom;
+                break;
+            default:
+                throw new Error("Unsupported firebase auth provider " + provider);
+        }
+        return authState;
+    }
+    exports_1("authDataToAuthState", authDataToAuthState);
+    return {
+        setters:[],
+        execute: function() {
+            AuthBackend = (function () {
+                function AuthBackend() {
+                }
+                return AuthBackend;
+            })();
+            exports_1("AuthBackend", AuthBackend);
+            (function (AuthProviders) {
+                AuthProviders[AuthProviders["Github"] = 0] = "Github";
+                AuthProviders[AuthProviders["Twitter"] = 1] = "Twitter";
+                AuthProviders[AuthProviders["Facebook"] = 2] = "Facebook";
+                AuthProviders[AuthProviders["Google"] = 3] = "Google";
+                AuthProviders[AuthProviders["Password"] = 4] = "Password";
+                AuthProviders[AuthProviders["Anonymous"] = 5] = "Anonymous";
+                AuthProviders[AuthProviders["Custom"] = 6] = "Custom";
+            })(AuthProviders || (AuthProviders = {}));
+            exports_1("AuthProviders", AuthProviders);
+            ;
+            (function (AuthMethods) {
+                AuthMethods[AuthMethods["Popup"] = 0] = "Popup";
+                AuthMethods[AuthMethods["Redirect"] = 1] = "Redirect";
+                AuthMethods[AuthMethods["Anonymous"] = 2] = "Anonymous";
+                AuthMethods[AuthMethods["Password"] = 3] = "Password";
+                AuthMethods[AuthMethods["OAuthToken"] = 4] = "OAuthToken";
+                AuthMethods[AuthMethods["CustomToken"] = 5] = "CustomToken";
+            })(AuthMethods || (AuthMethods = {}));
+            exports_1("AuthMethods", AuthMethods);
+            ;
+        }
+    }
+});

--- a/angularfire2/providers/auth_backend.ts
+++ b/angularfire2/providers/auth_backend.ts
@@ -1,0 +1,116 @@
+export abstract class AuthBackend {
+  abstract authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState>;
+  abstract authAnonymously(options?: any): Promise<FirebaseAuthState>;
+  abstract authWithPassword(credentials: FirebaseCredentials, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+    : Promise<FirebaseAuthState>;
+  abstract onAuth(onComplete: (authData: FirebaseAuthData) => void): void;
+  abstract getAuth(): FirebaseAuthData;
+  abstract unauth(): void;
+  abstract createUser(credentials: FirebaseCredentials): Promise<FirebaseAuthData>;
+}
+
+// Firebase only provides typings for google
+export interface FirebaseAuthDataAllProviders extends FirebaseAuthData {
+  github?: any;
+  twitter?: any;
+  google?: any;
+  facebook?: any;
+  password?: any;
+  anonymous?: any;
+}
+
+export enum AuthProviders {
+  Github,
+  Twitter,
+  Facebook,
+  Google,
+  Password,
+  Anonymous,
+  Custom
+};
+
+export enum AuthMethods {
+  Popup,
+  Redirect,
+  Anonymous,
+  Password,
+  OAuthToken,
+  CustomToken
+};
+
+
+export interface AuthConfiguration {
+  method?: AuthMethods;
+  provider?: AuthProviders;
+  remember?: string;
+  scope?: string[];
+}
+
+export interface OAuth2Credentials {
+  token: string;
+}
+
+export interface OAuth1Credentials {
+  user_id: string;
+  oauth_token: string;
+  oauth_token_secret: string;
+}
+
+export type OAuthCredentials = OAuth1Credentials | OAuth2Credentials;
+
+export type AuthCredentials = FirebaseCredentials | OAuthCredentials;
+
+export interface FirebaseAuthState {
+  uid: string;
+  provider: AuthProviders;
+  auth: Object;
+  expires?: number;
+  github?: any;
+  google?: any;
+  twitter?: any;
+  facebook?: any;
+  password?: any;
+  anonymous?: any;
+}
+
+export function authDataToAuthState(authData: FirebaseAuthDataAllProviders): FirebaseAuthState {
+  let {auth, uid, provider, github, twitter, facebook, google, password, anonymous} = authData;
+  let authState: FirebaseAuthState = { auth, uid, expires: authData.expires, provider: null };
+  switch (provider) {
+    case 'github':
+      authState.github = github;
+      authState.provider = AuthProviders.Github;
+      break;
+    case 'twitter':
+      authState.twitter = twitter;
+      authState.provider = AuthProviders.Twitter;
+      break;
+    case 'facebook':
+      authState.facebook = facebook;
+      authState.provider = AuthProviders.Facebook;
+      break;
+    case 'google':
+      authState.google = google;
+      authState.provider = AuthProviders.Google;
+      break;
+    case 'password':
+      authState.password = password;
+      authState.provider = AuthProviders.Password;
+      break;
+    case 'anonymous':
+      authState.anonymous = anonymous;
+      authState.provider = AuthProviders.Anonymous;
+      break;
+    case 'custom':
+      authState.provider = AuthProviders.Custom;
+      break;
+    default:
+      throw new Error(`Unsupported firebase auth provider ${provider}`);
+  }
+
+  return authState;
+}
+

--- a/angularfire2/providers/firebase_sdk_auth_backend.js
+++ b/angularfire2/providers/firebase_sdk_auth_backend.js
@@ -1,0 +1,163 @@
+System.register(['angular2/core', './auth_backend', '../tokens', '../utils/utils', 'firebase'], function(exports_1) {
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var __metadata = (this && this.__metadata) || function (k, v) {
+        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+    };
+    var __param = (this && this.__param) || function (paramIndex, decorator) {
+        return function (target, key) { decorator(target, key, paramIndex); }
+    };
+    var core_1, auth_backend_1, tokens_1, utils_1, Firebase;
+    var FirebaseSdkAuthBackend;
+    return {
+        setters:[
+            function (core_1_1) {
+                core_1 = core_1_1;
+            },
+            function (auth_backend_1_1) {
+                auth_backend_1 = auth_backend_1_1;
+            },
+            function (tokens_1_1) {
+                tokens_1 = tokens_1_1;
+            },
+            function (utils_1_1) {
+                utils_1 = utils_1_1;
+            },
+            function (Firebase_1) {
+                Firebase = Firebase_1;
+            }],
+        execute: function() {
+            FirebaseSdkAuthBackend = (function (_super) {
+                __extends(FirebaseSdkAuthBackend, _super);
+                function FirebaseSdkAuthBackend(_fbRef, _webWorkerMode) {
+                    if (_webWorkerMode === void 0) { _webWorkerMode = false; }
+                    _super.call(this);
+                    this._fbRef = _fbRef;
+                    this._webWorkerMode = _webWorkerMode;
+                }
+                FirebaseSdkAuthBackend.prototype.createUser = function (creds) {
+                    var _this = this;
+                    return new Promise(function (resolve, reject) {
+                        _this._fbRef.createUser(creds, function (err, authData) {
+                            if (err) {
+                                reject(err);
+                            }
+                            else {
+                                resolve(authData);
+                            }
+                        });
+                    });
+                };
+                FirebaseSdkAuthBackend.prototype.onAuth = function (onComplete) {
+                    this._fbRef.onAuth(onComplete);
+                };
+                FirebaseSdkAuthBackend.prototype.getAuth = function () {
+                    return this._fbRef.getAuth();
+                };
+                FirebaseSdkAuthBackend.prototype.unauth = function () {
+                    this._fbRef.unauth();
+                };
+                FirebaseSdkAuthBackend.prototype.authWithCustomToken = function (token, options) {
+                    var _this = this;
+                    var p = new Promise(function (res, rej) {
+                        _this._fbRef.authWithCustomToken(token, _this._handleFirebaseCb(res, rej, options), options);
+                    });
+                    return p;
+                };
+                FirebaseSdkAuthBackend.prototype.authAnonymously = function (options) {
+                    var _this = this;
+                    var p = new Promise(function (res, rej) {
+                        _this._fbRef.authAnonymously(_this._handleFirebaseCb(res, rej, options), options);
+                    });
+                    return p;
+                };
+                FirebaseSdkAuthBackend.prototype.authWithPassword = function (credentials, options) {
+                    var _this = this;
+                    var p = new Promise(function (res, rej) {
+                        _this._fbRef.authWithPassword(credentials, _this._handleFirebaseCb(res, rej, options), options);
+                    });
+                    return p;
+                };
+                FirebaseSdkAuthBackend.prototype.authWithOAuthPopup = function (provider, options) {
+                    var _this = this;
+                    var p = new Promise(function (res, rej) {
+                        _this._fbRef.authWithOAuthPopup(_this._providerToString(provider), _this._handleFirebaseCb(res, rej, options), options);
+                    });
+                    return p;
+                };
+                /**
+                 * Authenticates a Firebase client using a redirect-based OAuth flow
+                 * NOTE: This promise will not be resolved if authentication is successful since the browser redirected.
+                 * You should subscribe to the FirebaseAuth object to listen succesful login
+                 */
+                FirebaseSdkAuthBackend.prototype.authWithOAuthRedirect = function (provider, options) {
+                    var _this = this;
+                    var p = new Promise(function (res, rej) {
+                        _this._fbRef.authWithOAuthRedirect(_this._providerToString(provider), _this._handleFirebaseCb(res, rej, options), options);
+                    });
+                    return p;
+                };
+                FirebaseSdkAuthBackend.prototype.authWithOAuthToken = function (provider, credentialsObj, options) {
+                    var _this = this;
+                    var p = new Promise(function (res, rej) {
+                        var credentials = utils_1.isPresent(credentialsObj.token)
+                            ? credentialsObj.token
+                            : credentialsObj;
+                        _this._fbRef.authWithOAuthToken(_this._providerToString(provider), credentials, _this._handleFirebaseCb(res, rej, options), options);
+                    });
+                    return p;
+                };
+                FirebaseSdkAuthBackend.prototype._handleFirebaseCb = function (res, rej, options) {
+                    var _this = this;
+                    return function (err, auth) {
+                        if (err) {
+                            return rej(err);
+                        }
+                        else {
+                            if (!_this._webWorkerMode)
+                                return res(auth_backend_1.authDataToAuthState(auth));
+                            else {
+                                if (utils_1.isPresent(options) && utils_1.isPresent(options.remember)) {
+                                    // Add remember value in WebWorker mode so that the worker
+                                    // can auth with the same value
+                                    auth.remember = options.remember;
+                                }
+                                return res(auth);
+                            }
+                        }
+                    };
+                };
+                FirebaseSdkAuthBackend.prototype._providerToString = function (provider) {
+                    switch (provider) {
+                        case auth_backend_1.AuthProviders.Github:
+                            return 'github';
+                        case auth_backend_1.AuthProviders.Twitter:
+                            return 'twitter';
+                        case auth_backend_1.AuthProviders.Facebook:
+                            return 'facebook';
+                        case auth_backend_1.AuthProviders.Google:
+                            return 'google';
+                        default:
+                            throw new Error("Unsupported firebase auth provider " + provider);
+                    }
+                };
+                FirebaseSdkAuthBackend = __decorate([
+                    core_1.Injectable(),
+                    __param(0, core_1.Inject(tokens_1.FirebaseRef)), 
+                    __metadata('design:paramtypes', [Firebase, Object])
+                ], FirebaseSdkAuthBackend);
+                return FirebaseSdkAuthBackend;
+            })(auth_backend_1.AuthBackend);
+            exports_1("FirebaseSdkAuthBackend", FirebaseSdkAuthBackend);
+        }
+    }
+});

--- a/angularfire2/providers/firebase_sdk_auth_backend.ts
+++ b/angularfire2/providers/firebase_sdk_auth_backend.ts
@@ -1,0 +1,140 @@
+import {Injectable, Inject} from 'angular2/core';
+import {
+  AuthBackend,
+  FirebaseAuthState,
+  AuthProviders,
+  AuthMethods,
+  authDataToAuthState,
+  OAuth2Credentials,
+  OAuthCredentials
+} from './auth_backend';
+import {FirebaseRef} from '../tokens';
+import {isPresent} from '../utils/utils';
+import * as Firebase from 'firebase';
+
+@Injectable()
+export class FirebaseSdkAuthBackend extends AuthBackend {
+  constructor( @Inject(FirebaseRef) private _fbRef: Firebase,
+    private _webWorkerMode = false) {
+    super();
+  }
+
+  createUser(creds: FirebaseCredentials): Promise<FirebaseAuthData> {
+    return new Promise<FirebaseAuthData>((resolve, reject) => {
+      this._fbRef.createUser(creds, (err, authData) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(authData);
+        }
+      });
+    });
+  }
+
+  onAuth(onComplete: (authData: FirebaseAuthData) => void): void {
+    this._fbRef.onAuth(onComplete);
+  }
+
+  getAuth(): FirebaseAuthData {
+    return this._fbRef.getAuth();
+  }
+
+  unauth(): void {
+    this._fbRef.unauth();
+  }
+
+  authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(token, this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authAnonymously(options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authAnonymously(this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithPassword(credentials: FirebaseCredentials, options?: any)
+    : Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithPassword(credentials, this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithOAuthPopup(this._providerToString(provider),
+        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  /**
+   * Authenticates a Firebase client using a redirect-based OAuth flow
+   * NOTE: This promise will not be resolved if authentication is successful since the browser redirected.
+   * You should subscribe to the FirebaseAuth object to listen succesful login
+   */
+  authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithOAuthRedirect(this._providerToString(provider),
+        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+    : Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      let credentials = isPresent((<OAuth2Credentials>credentialsObj).token)
+        ? (<OAuth2Credentials>credentialsObj).token
+        : credentialsObj;
+      this._fbRef.authWithOAuthToken(this._providerToString(provider), credentials,
+        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  private _handleFirebaseCb(res: Function, rej: Function, options: any): (err: any, auth?: FirebaseAuthData) => void {
+    return (err, auth?) => {
+      if (err) {
+        return rej(err);
+      } else {
+        if (!this._webWorkerMode)
+          return res(authDataToAuthState(auth));
+        else {
+          if (isPresent(options) && isPresent(options.remember)) {
+            // Add remember value in WebWorker mode so that the worker
+            // can auth with the same value
+            (<any>auth).remember = options.remember;
+          }
+          return res(auth);
+        }
+      }
+    };
+  }
+
+  private _providerToString(provider: AuthProviders): string {
+    switch (provider) {
+      case AuthProviders.Github:
+        return 'github';
+      case AuthProviders.Twitter:
+        return 'twitter';
+      case AuthProviders.Facebook:
+        return 'facebook';
+      case AuthProviders.Google:
+        return 'google';
+      default:
+        throw new Error(`Unsupported firebase auth provider ${provider}`);
+    }
+  }
+}

--- a/angularfire2/providers/web_workers/shared/channels.ts
+++ b/angularfire2/providers/web_workers/shared/channels.ts
@@ -1,0 +1,2 @@
+export const AUTH_CHANNEL = 'angularfire2-auth';
+export const INITIAL_AUTH_CHANNEL = 'angularfire2-auth-initial';

--- a/angularfire2/providers/web_workers/ui/auth.ts
+++ b/angularfire2/providers/web_workers/ui/auth.ts
@@ -1,0 +1,35 @@
+import {Injectable, Inject} from 'angular2/core';
+import {ServiceMessageBrokerFactory, PRIMITIVE} from 'angular2/platform/worker_render';
+import {AUTH_CHANNEL, INITIAL_AUTH_CHANNEL} from '../shared/channels';
+import {FirebaseRef} from '../../../tokens';
+import {FirebaseAuthState} from '../../auth_backend';
+import {FirebaseSdkAuthBackend} from '../../firebase_sdk_auth_backend';
+
+@Injectable()
+export class MessageBasedFirebaseAuth {
+  constructor(private _sdkBackend: FirebaseSdkAuthBackend,
+              private _brokerFactory: ServiceMessageBrokerFactory) {
+  }
+
+  start(): void {
+    let broker = this._brokerFactory.createMessageBroker(AUTH_CHANNEL);
+    broker.registerMethod('authAnonymously', [PRIMITIVE], this._sdkBackend.authAnonymously.bind(this._sdkBackend),
+                          PRIMITIVE);
+    broker.registerMethod('authWithPassword', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithPassword.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthPopup', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthPopup.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthRedirect', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthRedirect.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthToken', [PRIMITIVE, PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthToken.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('getAuth', null, this._getAuth.bind(this), PRIMITIVE);
+    broker.registerMethod('unauth', null, this._sdkBackend.unauth.bind(this._sdkBackend));
+  }
+
+  private _getAuth(): Promise<FirebaseAuthData> {
+    return new Promise((res, rej) => {
+      res(this._sdkBackend.getAuth());
+    });
+  }
+}

--- a/angularfire2/providers/web_workers/worker/auth.ts
+++ b/angularfire2/providers/web_workers/worker/auth.ts
@@ -1,0 +1,147 @@
+import {Injectable, Inject} from 'angular2/core';
+
+// Import these from src/ until we have a specific import path for them
+// https://github.com/angular/angular/issues/7419
+import {
+  ClientMessageBrokerFactory,
+  ClientMessageBroker,
+  FnArg,
+  UiArguments
+} from 'angular2/src/web_workers/shared/client_message_broker';
+import {MessageBus} from 'angular2/src/web_workers/shared/message_bus';
+import {PRIMITIVE} from 'angular2/src/web_workers/shared/serializer';
+
+import {AUTH_CHANNEL, INITIAL_AUTH_CHANNEL} from '../shared/channels';
+import {FirebaseRef} from '../../../tokens';
+import {
+  AuthBackend,
+  FirebaseAuthState,
+  AuthProviders,
+  AuthMethods,
+  authDataToAuthState,
+  OAuth2Credentials,
+  OAuthCredentials
+} from '../../auth_backend';
+import {isPresent} from '../../../utils/utils';
+import * as Firebase from 'firebase';
+
+@Injectable()
+export class WebWorkerFirebaseAuth extends AuthBackend {
+  private _messageBroker: ClientMessageBroker;
+  private _authMetadata: {[key: string]: FirebaseAuthData} = {};
+  private _authCbs: Array<(authData: FirebaseAuthData) => void> = [];
+  private _gotAuth = false;
+
+  constructor (@Inject(FirebaseRef) private _fbRef: Firebase, brokerFactory: ClientMessageBrokerFactory,
+              bus: MessageBus) {
+    super();
+    this._messageBroker = brokerFactory.createMessageBroker(AUTH_CHANNEL);
+    let args = new UiArguments('getAuth');
+    this._messageBroker.runOnService(args, PRIMITIVE).then((authData: FirebaseAuthDataWithRemember) => {
+      this._gotAuth = true;
+      if (authData != null) {
+        this._handleAuthPromise(<FirebaseAuthDataWithRemember> authData);
+      }
+    });
+  }
+
+  onAuth (onComplete: (authData: FirebaseAuthData) => void): void {
+    this._fbRef.onAuth((authData) => {
+      if (!this._gotAuth) return false;
+      if (isPresent(authData) && isPresent(this._authMetadata[authData.token])) {
+        authData = this._authMetadata[authData.token];
+      }
+      onComplete(authData);
+    });
+  }
+
+  getAuth(): FirebaseAuthData {
+    return this._fbRef.getAuth();
+  }
+  
+  createUser(creds: FirebaseCredentials): Promise<FirebaseAuthData> {
+    return new Promise<FirebaseAuthData>((resolve, reject) => {
+      this._fbRef.createUser(creds, (err, authData) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(authData);
+        }
+      });
+    });
+  }
+
+  authAnonymously(options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authAnonymously', [new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+
+  authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
+    return new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(token, (err, authData) => {
+        if (err)
+          return rej(err);
+        else
+          return res(authDataToAuthState(authData));
+      });
+    });
+  }
+  authWithPassword(credentials: FirebaseCredentials, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithPassword',
+                               [new FnArg(credentials, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthPopup',
+                               [new FnArg(provider, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthRedirect',
+                               [new FnArg(provider, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+  : Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthToken',
+                               [new FnArg(provider, PRIMITIVE), 
+                                new FnArg(credentialsObj, PRIMITIVE),
+                                new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+
+  unauth(): void {
+    let args = new UiArguments('unauth');
+    this._messageBroker.runOnService(args, null);
+    this._fbRef.unauth();
+  }
+
+  /**
+   * Performs custom token auth using the token returned from the UI.
+   * Saves the associated metatadata to be emited by onAuth.
+   */
+  private _doAuth(promise: Promise<FirebaseAuthDataWithRemember>): Promise<FirebaseAuthState> {
+    return promise.then((data) => this._handleAuthPromise(data));
+  }
+
+  private _handleAuthPromise(authData: FirebaseAuthDataWithRemember): Promise<FirebaseAuthState> {
+    this._authMetadata[authData.token] = authData;
+    return new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(authData.token, (err, _) => {
+        if (err)
+          return rej (err);
+        else 
+          return res(authDataToAuthState(authData));
+      }, {remember: authData.remember});
+    });
+  }
+}
+
+interface FirebaseAuthDataWithRemember extends FirebaseAuthData {
+  remember: string;
+}

--- a/angularfire2/src/angularfire2.spec.ts
+++ b/angularfire2/src/angularfire2.spec.ts
@@ -1,0 +1,161 @@
+import {
+  describe,
+  ddescribe,
+  it,
+  iit,
+  beforeEach,
+  beforeEachProviders,
+  expect,
+  inject,
+  injectAsync
+} from 'angular2/testing';
+import {Injector, provide, Provider} from 'angular2/core';
+import {
+  AngularFire,
+  FirebaseObjectObservable,
+  FIREBASE_PROVIDERS,
+  FirebaseAuth,
+  FirebaseUrl,
+  FirebaseRef,
+  defaultFirebase
+} from './angularfire2';
+import {Subscription} from 'rxjs';
+import 'rxjs/add/operator/toPromise';
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/delay';
+
+// Only use this URL for angularfire2.spec.ts
+const localServerUrl = 'https://angularfire2.firebaseio-demo.com/';
+
+describe('angularfire', () => {
+  var subscription:Subscription;
+  const questionsRef = new Firebase(localServerUrl).child('questions');
+  const listOfQuestionsRef = new Firebase(localServerUrl).child('list-of-questions');
+
+  afterEach((done:any) => {
+    // Clear out the Firebase to prevent leaks between tests
+    (new Firebase(localServerUrl)).remove(done);
+    if(subscription && !subscription.isUnsubscribed) {
+      subscription.unsubscribe();
+    }
+  });
+
+
+  it('should be injectable via FIREBASE_PROVIDERS', () => {
+    var injector = Injector.resolveAndCreate([FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+    expect(injector.get(AngularFire)).toBeAnInstanceOf(AngularFire);
+  });
+
+  describe('.list()', () => {
+    var af:AngularFire;
+    beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+    beforeEach(inject([AngularFire], (_af:AngularFire) => {
+      af = _af;
+    }));
+
+
+    it('should accept an absolute url', () => {
+      expect((<any>af.list(localServerUrl))._ref.toString()).toBe(localServerUrl);
+    });
+
+
+    it('should return an observable of the path', (done:any) => {
+      var questions = af.list(`/questions`);
+      questionsRef.push({pathObservable:true}, () => {
+        subscription = questions
+          .take(1)
+          .do((data:any) => {
+            expect(data.length).toBe(1);
+            expect(data[0].pathObservable).toBe(true);
+          })
+          .subscribe(done, done.fail);
+      });
+    });
+
+
+    it('should preserve snapshots in the list if preserveSnapshot option specified', (done:any) => {
+      var questions = af.list(`list-of-questions`, {preserveSnapshot: true});
+      listOfQuestionsRef.push('hello', () => {
+        subscription = questions
+          .take(1)
+          .do((data:any) => {
+            expect(data[0].val()).toEqual('hello');
+          })
+          .subscribe(done, done.fail);
+      });
+    });
+  });
+
+
+  describe('.object()', () => {
+    var observable:FirebaseObjectObservable<any>;
+    var af:AngularFire;
+
+    beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+    beforeEach(inject([AngularFire], (_af:AngularFire) => {
+      observable = _af.object(`/list-of-questions/1`)
+      af = _af;
+    }));
+
+
+    it('should accept an absolute url', () => {
+      expect((<any>af.object(localServerUrl))._ref.toString()).toBe(localServerUrl);
+    });
+
+
+    it('should return an observable of the path', injectAsync([AngularFire], (af:AngularFire) => {
+      return (<any>observable)._ref.set({title: 'how to firebase?'})
+        .then(() => observable.take(1).toPromise())
+        .then((data:any) => {
+          expect(data).toEqual({title: 'how to firebase?'});
+        });
+    }));
+
+
+    it('should preserve snapshot if preserveSnapshot option specified', injectAsync([AngularFire], (af:AngularFire) => {
+      observable = af.object(`list-of-questions/`, {preserveSnapshot: true});
+      return (<any>observable)._ref.set({title: 'how to firebase?'})
+        .then(() => observable.take(1).toPromise())
+        .then((data:any) => {
+          expect(data.val()).toEqual({title: 'how to firebase?'});
+        });
+    }));
+  });
+
+
+  describe('.auth', () => {
+    beforeEachProviders(() => [FIREBASE_PROVIDERS, defaultFirebase(localServerUrl)]);
+
+    it('should be an instance of AuthService', inject([AngularFire], (af:AngularFire) => {
+      expect(af.auth).toBeAnInstanceOf(FirebaseAuth);
+    }));
+  });
+
+
+  describe('FIREBASE_REF', () => {
+    it('should provide a FirebaseRef for the FIREBASE_REF binding', () => {
+      var injector = Injector.resolveAndCreate([
+        provide(FirebaseUrl, {
+          useValue: localServerUrl
+        }),
+        FIREBASE_PROVIDERS
+      ]);
+      expect(typeof injector.get(FirebaseRef).on).toBe('function');
+    })
+  });
+
+  describe('defaultFirebase', () => {
+    it('should create a provider', () => {
+      const provider = defaultFirebase(localServerUrl);
+      expect(provider).toBeAnInstanceOf(Provider);
+    });
+
+
+    it('should inject a FIR reference', () => {
+      const injector = Injector.resolveAndCreate([defaultFirebase(localServerUrl), FIREBASE_PROVIDERS]);
+      expect(injector.get(FirebaseRef).toString()).toBe(localServerUrl);
+    });
+  });
+
+});

--- a/angularfire2/src/angularfire2.ts
+++ b/angularfire2/src/angularfire2.ts
@@ -1,0 +1,89 @@
+import {APP_INITIALIZER, Inject, Injectable, OpaqueToken, provide, Provider} from 'angular2/core';
+import {FirebaseAuth, firebaseAuthConfig} from './providers/auth';
+import * as Firebase from 'firebase';
+import {FirebaseListObservable} from './utils/firebase_list_observable';
+import {FirebaseObjectObservable} from './utils/firebase_object_observable';
+import {FirebaseListFactory, FirebaseListFactoryOpts} from './utils/firebase_list_factory';
+import {
+  FirebaseObjectFactoryOpts,
+  FirebaseObjectFactory
+} from './utils/firebase_object_factory';
+import {FirebaseUrl, FirebaseRef} from './tokens';
+import {
+  AuthBackend,
+  AuthMethods,
+  AuthProviders,
+  FirebaseAuthState
+} from './providers/auth_backend';
+import {FirebaseSdkAuthBackend} from './providers/firebase_sdk_auth_backend';
+import {FirebaseDatabase} from './database/database';
+
+@Injectable()
+export class AngularFire {
+  list: (url:string, opts?:FirebaseListFactoryOpts) => FirebaseListObservable<any[]>;
+  object: (url: string, opts?:FirebaseObjectFactoryOpts) => FirebaseObjectObservable<any>;
+  constructor(
+    @Inject(FirebaseUrl) private fbUrl:string,
+    public auth:FirebaseAuth,
+    public database: FirebaseDatabase) {
+      this.list = database.list.bind(database);
+      this.object = database.object.bind(database);
+  }
+
+}
+
+function getAbsUrl (root:string, url:string) {
+  if (!(/^[a-z]+:\/\/.*/.test(url))) {
+    // Provided url is relative.
+    url = root + url;
+  }
+  return url;
+}
+
+export const COMMON_PROVIDERS: any[] = [
+  provide(FirebaseRef, {
+    useFactory: (url:string) => new Firebase(url),
+    deps: [FirebaseUrl]}),
+  FirebaseAuth,
+  AngularFire,
+  FirebaseDatabase
+];
+
+export const FIREBASE_PROVIDERS:any[] = [
+  COMMON_PROVIDERS,
+  provide(AuthBackend, {
+    useFactory: (ref: Firebase) => new FirebaseSdkAuthBackend(ref, false),
+    deps: [FirebaseRef]
+  })
+];
+
+/**
+ * Used to define the default Firebase root location to be
+ * used throughout an application.
+ */
+export const defaultFirebase = (url: string): Provider => {
+  return provide(FirebaseUrl, {
+    useValue: url
+  });
+};
+
+export {
+  FirebaseAuth,
+  FirebaseDatabase,
+  FirebaseListObservable,
+  FirebaseObjectObservable,
+  FirebaseListFactory,
+  FirebaseObjectFactory,
+  firebaseAuthConfig,
+  FirebaseAuthState,
+  AuthMethods,
+  AuthProviders
+}
+
+export {FirebaseUrl, FirebaseRef, FirebaseAuthConfig} from './tokens';
+
+// Helps Angular-CLI automatically add providers
+export default {
+  providers: FIREBASE_PROVIDERS
+}
+

--- a/angularfire2/src/angularfire2_worker_app.ts
+++ b/angularfire2/src/angularfire2_worker_app.ts
@@ -1,0 +1,9 @@
+import {provide} from 'angular2/core';
+import {COMMON_PROVIDERS} from './angularfire2';
+import {AuthBackend} from './providers/auth_backend';
+import {WebWorkerFirebaseAuth} from './providers/web_workers/worker/auth';
+
+export const WORKER_APP_FIREBASE_PROVIDERS: any[] = [
+  COMMON_PROVIDERS,
+  provide(AuthBackend, {useClass: WebWorkerFirebaseAuth})
+];

--- a/angularfire2/src/angularfire2_worker_render.ts
+++ b/angularfire2/src/angularfire2_worker_render.ts
@@ -1,0 +1,17 @@
+import {provide} from 'angular2/core';
+import {COMMON_PROVIDERS} from './angularfire2';
+import {FirebaseSdkAuthBackend} from './providers/firebase_sdk_auth_backend';
+import {WebWorkerFirebaseAuth} from './providers/web_workers/worker/auth';
+import {FirebaseRef} from './tokens';
+import {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';
+
+export const WORKER_RENDER_FIREBASE_PROVIDERS: any[] = [
+  COMMON_PROVIDERS,
+  provide(FirebaseSdkAuthBackend, {
+    useFactory: (ref: Firebase) => new FirebaseSdkAuthBackend(ref, true),
+    deps: [FirebaseRef]
+  }),
+  MessageBasedFirebaseAuth
+];
+
+export {MessageBasedFirebaseAuth} from './providers/web_workers/ui/auth';

--- a/angularfire2/src/database/database.ts
+++ b/angularfire2/src/database/database.ts
@@ -1,0 +1,32 @@
+import {Inject, Injectable} from 'angular2/core';
+import {FirebaseUrl} from '../tokens';
+import {FirebaseListObservable} from '../utils/firebase_list_observable';
+import {FirebaseObjectObservable} from '../utils/firebase_object_observable';
+import {FirebaseListFactory, FirebaseListFactoryOpts} from '../utils/firebase_list_factory';
+import {FirebaseObjectFactoryOpts, FirebaseObjectFactory} from '../utils/firebase_object_factory';
+import * as utils from '../utils/utils'
+
+@Injectable()
+export class FirebaseDatabase {
+  constructor(@Inject(FirebaseUrl) private fbUrl:string) {}
+  list (urlOrRef:string | Firebase | FirebaseQuery, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
+    return utils.checkForUrlOrFirebaseRef(urlOrRef, {
+      isUrl: () => FirebaseListFactory(getAbsUrl(this.fbUrl, <string>urlOrRef), opts),
+      isRef: () => FirebaseListFactory(<Firebase>urlOrRef)
+    });
+  }
+  object(urlOrRef: string | Firebase | FirebaseQuery, opts?:FirebaseObjectFactoryOpts):FirebaseObjectObservable<any> {
+    return utils.checkForUrlOrFirebaseRef(urlOrRef, {
+      isUrl: () => FirebaseObjectFactory(getAbsUrl(this.fbUrl, <string>urlOrRef), opts),
+      isRef: () => FirebaseObjectFactory(urlOrRef)
+    });
+  }
+}
+
+function getAbsUrl (root:string, url:string) {
+  if (!(/^[a-z]+:\/\/.*/.test(url))) {
+    // Provided url is relative.
+    url = root + url;
+  }
+  return url;
+}

--- a/angularfire2/src/providers/auth.spec.ts
+++ b/angularfire2/src/providers/auth.spec.ts
@@ -1,0 +1,509 @@
+/// <reference path="../../manual_typings/manual_typings.d.ts" />
+
+import {expect, describe, it, iit, beforeEach} from 'angular2/testing';
+import {Injector, provide, Provider} from 'angular2/core';
+import {Observable} from 'rxjs/Observable'
+import {
+  FIREBASE_PROVIDERS,
+  FirebaseRef,
+  FirebaseUrl,
+  FirebaseAuth,
+  AuthMethods,
+  FirebaseAuthState,
+  firebaseAuthConfig,
+  AuthProviders
+} from '../angularfire2';
+import {AuthBackend} from './auth_backend';
+import {FirebaseSdkAuthBackend} from './firebase_sdk_auth_backend';
+import * as Firebase from 'firebase';
+import * as mockPromises from 'mock-promises';
+
+describe('FirebaseAuth', () => {
+  let injector: Injector = null;
+  let ref: Firebase = null;
+  let authData: any = null;
+  let authCb: any = null;
+  let backend: AuthBackend = null;
+
+  const providerMetadata = {
+    accessToken: 'accessToken',
+    displayName: 'github User',
+    username: 'githubUsername',
+    id: '12345',
+    expires: 0
+  }
+
+  const authObj = {
+    token: 'key'
+  }
+
+  const authState = {
+    provider: 'github',
+    uid: 'github:12345',
+    github: providerMetadata,
+    auth: authObj,
+    expires: 0
+  };
+
+  const AngularFireAuthState = {
+    provider: AuthProviders.Github,
+    uid: 'github:12345',
+    github: providerMetadata,
+    auth: authObj,
+    expires: 0
+  }
+
+  beforeEach(() => {
+    authData = null;
+    authCb = null;
+    injector = Injector.resolveAndCreate([
+      provide(FirebaseUrl, {
+        useValue: 'https://angularfire2-auth.firebaseio-demo.com/'
+      }),
+      FIREBASE_PROVIDERS
+    ]);
+
+  });
+
+
+  it('should be an observable', () => {
+    expect(injector.get(FirebaseAuth)).toBeAnInstanceOf(Observable);
+  })
+
+  describe('AuthState', () => {
+
+    beforeEach(() => {
+      ref = injector.get(FirebaseRef);
+      spyOn(ref, 'onAuth').and.callFake((fn: (a: any) => void) => {
+        authCb = fn;
+        if (authCb !== null) {
+          authCb(authData);
+        }
+      });
+      backend = new FirebaseSdkAuthBackend(ref);
+    });
+    function updateAuthState(_authData: any): void {
+      authData = _authData;
+      if (authCb !== null) {
+        authCb(authData);
+      }
+    }
+
+    it('should synchronously load firebase auth data', () => {
+      updateAuthState(authState);
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(AngularFireAuthState);
+    });
+
+    it('should be null if user is not authed', () => {
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(null);
+    });
+
+    it('should emit auth updates', (done: () => void) => {
+      let nextSpy = jasmine.createSpy('nextSpy');
+      let auth = injector.get(FirebaseAuth);
+
+      auth.subscribe(nextSpy);
+      expect(nextSpy).toHaveBeenCalledWith(null);
+      setTimeout(() => {
+        nextSpy.calls.reset();
+
+        updateAuthState(authState);
+        expect(nextSpy).toHaveBeenCalledWith(AngularFireAuthState);
+        done();
+      }, 1);
+    });
+  });
+
+  function getArgIndex(callbackName: string): number {
+    //In the firebase API, the completion callback is the second argument for all but a few functions.
+    switch (callbackName) {
+      case 'authAnonymously':
+      case 'onAuth':
+        return 0;
+      case 'authWithOAuthToken':
+        return 2;
+      default:
+        return 1;
+    }
+  }
+
+  // calls the firebase callback
+  function callback(callbackName: string, callIndex?: number): Function {
+    callIndex = callIndex || 0; //assume the first call.
+    var argIndex = getArgIndex(callbackName);
+    return (<any>ref)[callbackName].calls.argsFor(callIndex)[argIndex];
+  }
+
+  describe('firebaseAuthConfig', () => {
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+    });
+
+    it('should return a provider', () => {
+      expect(firebaseAuthConfig({ method: AuthMethods.Password })).toBeAnInstanceOf(Provider);
+    });
+
+    it('should use config in login', () => {
+      let config = {
+        method: AuthMethods.Anonymous
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login();
+      expect(ref.authAnonymously).toHaveBeenCalled();
+    });
+
+    it('should pass options on to login method', () => {
+      let config = {
+        method: AuthMethods.Anonymous,
+        remember: 'default'
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login();
+      expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
+    });
+
+    it('should be overridden by login\'s arguments', () => {
+      let config = {
+        method: AuthMethods.Anonymous
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login({
+        method: AuthMethods.Popup,
+        provider: AuthProviders.Google
+      });
+      expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('google', jasmine.any(Function), {});
+    });
+
+    it('should be merged with login\'s arguments', () => {
+      let config = {
+        method: AuthMethods.Popup,
+        provider: AuthProviders.Google,
+        scope: ['email']
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login({
+        provider: AuthProviders.Github
+      });
+      expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('github', jasmine.any(Function), {
+        scope: ['email']
+      });
+    });
+  });
+
+  describe('createUser', () => {
+    let auth: FirebaseAuth = null;
+    let credentials = { email: 'myname', password: 'password' };
+
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+      auth = new FirebaseAuth(backend);
+    });
+
+    it('should call createUser on a db reference', () => {
+      auth.createUser(credentials);
+      expect(ref.createUser)
+        .toHaveBeenCalledWith(credentials, jasmine.any(Function));
+    });
+
+  });
+
+  describe('login', () => {
+    let auth: FirebaseAuth = null;
+
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+      auth = new FirebaseAuth(backend);
+    });
+
+    it('should reject if password is used without credentials', (done: any) => {
+      let config = {
+        method: AuthMethods.Password
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    it('should reject if custom token is used without credentials', (done: any) => {
+      let config = {
+        method: AuthMethods.CustomToken
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);;
+    });
+
+    it('should reject if oauth token is used without credentials', (done: any) => {
+      let config = {
+        method: AuthMethods.OAuthToken
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    it('should reject if popup is used without a provider', (done: any) => {
+      let config = {
+        method: AuthMethods.Popup
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    it('should reject if redirect is used without a provider', (done: any) => {
+      let config = {
+        method: AuthMethods.Redirect
+      };
+      let auth = new FirebaseAuth(backend, config);
+      auth.login().then(done.fail, done);
+    });
+
+    describe('authWithCustomToken', () => {
+      let options = {
+        remember: 'default',
+        method: AuthMethods.CustomToken
+      };
+      let credentials = {
+        token: 'myToken'
+      };
+
+      it('passes custom token to underlying method', () => {
+        auth.login(credentials, options);
+        expect(ref.authWithCustomToken)
+          .toHaveBeenCalledWith('myToken', jasmine.any(Function), { remember: 'default' });
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(credentials, options).then(done.fail, done);
+        callback('authWithCustomToken')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(credentials, options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithCustomToken')(null, authState);
+      });
+    });
+
+    describe('authAnonymously', () => {
+      let options = {
+        remember: 'default',
+        method: AuthMethods.Anonymous
+      };
+      it('passes options object to underlying method', () => {
+        auth.login(options);
+        expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(options).then(done.fail, done);
+        callback('authAnonymously')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authAnonymously')(null, authState);
+      });
+    });
+
+    describe('authWithPassword', () => {
+      let options = { remember: 'default', method: AuthMethods.Password };
+      let credentials = { email: 'myname', password: 'password' };
+
+      it('should login with password credentials', () => {
+        let config = {
+          method: AuthMethods.Password,
+          provider: AuthProviders.Password
+        };
+        const credentials = {
+          email: 'david@fire.com',
+          password: 'supersecretpassword'
+        };
+        let auth = new FirebaseAuth(backend, config);
+        auth.login(credentials);
+        expect(ref.authWithPassword).toHaveBeenCalledWith(credentials,
+          jasmine.any(Function),
+          { provider: config.provider });
+      });
+
+      it('passes options and credentials object to underlying method', () => {
+        auth.login(credentials, options);
+        expect(ref.authWithPassword).toHaveBeenCalledWith(
+          credentials,
+          jasmine.any(Function),
+          { remember: options.remember }
+        );
+      });
+
+      it('will revoke the promise if authentication fails', (done: any) => {
+        auth.login(credentials, options).then(done.fail, done);
+        callback('authWithPassword')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(credentials, options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithPassword')(null, authState);
+      });
+    });
+
+    describe('authWithOAuthPopup', function() {
+      let options = {
+        method: AuthMethods.Popup,
+        provider: AuthProviders.Github
+      };
+      it('passes provider and options object to underlying method', () => {
+        let customOptions = Object.assign({}, options);
+        customOptions.scope = ['email'];
+        auth.login(customOptions);
+        expect(ref.authWithOAuthPopup).toHaveBeenCalledWith(
+          'github',
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(options).then(done.fail, done);
+        callback('authWithOAuthPopup')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithOAuthPopup')(null, authState);
+      });
+    });
+
+    describe('authWithOAuthRedirect', () => {
+      const options = {
+        method: AuthMethods.Redirect,
+        provider: AuthProviders.Github
+      };
+      it('passes provider and options object to underlying method', () => {
+        let customOptions = Object.assign({}, options);
+        customOptions.scope = ['email'];
+        auth.login(customOptions);
+        expect(ref.authWithOAuthRedirect).toHaveBeenCalledWith(
+          'github',
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        auth.login(options).then(done.fail, done);
+        callback('authWithOAuthRedirect')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithOAuthRedirect')(null, authState);
+      });
+    });
+
+    describe('authWithOAuthToken', () => {
+      const options = {
+        method: AuthMethods.OAuthToken,
+        provider: AuthProviders.Github,
+        scope: ['email']
+      };
+      const token = 'GITHUB_TOKEN';
+      const credentials = {
+        token: token
+      };
+      it('passes provider, token, and options object to underlying method', () => {
+        auth.login(credentials, options);
+        expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
+          'github',
+          token,
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('passes provider, OAuth credentials, and options object to underlying method', () => {
+        let customOptions = Object.assign({}, options);
+        customOptions.provider = AuthProviders.Twitter;
+        let twitterCredentials = {
+          "user_id": "<USER-ID>",
+          "oauth_token": "<ACCESS-TOKEN>",
+          "oauth_token_secret": "<ACCESS-TOKEN-SECRET>"
+        };
+        auth.login(twitterCredentials, customOptions);
+        expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
+          'twitter',
+          twitterCredentials,
+          jasmine.any(Function),
+          { scope: ['email'] }
+        );
+      });
+
+      it('will reject the promise if authentication fails', (done: any) => {
+        let creds = {
+          token: ''
+        };
+        auth.login(creds, options).then(done.fail, done);
+        callback('authWithOAuthToken')('myError');
+      });
+
+      it('will resolve the promise upon authentication', (done: any) => {
+        auth.login(credentials, options).then(result => {
+          expect(result).toEqual(AngularFireAuthState);
+          done();
+        }, done.fail);
+        callback('authWithOAuthToken')(null, authState);
+      });
+    });
+
+
+    describe('unauth()', () => {
+      it('will call unauth() on the backing ref if logged in', () => {
+        (<any>ref).getAuth.and.returnValue({ provider: 'twitter' }); auth.logout();
+        expect(ref.unauth).toHaveBeenCalled();
+      });
+
+      it('will NOT call unauth() on the backing ref if NOT logged in', () => {
+        (<any>ref).getAuth.and.returnValue(null);
+        auth.logout();
+        expect(ref.unauth).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+

--- a/angularfire2/src/providers/auth.ts
+++ b/angularfire2/src/providers/auth.ts
@@ -1,0 +1,141 @@
+import {Provider, Inject, provide, Injectable, Optional} from 'angular2/core';
+import {ReplaySubject} from 'rxjs/subject/ReplaySubject';
+import {FirebaseRef, FirebaseAuthConfig} from '../tokens';
+import {isPresent} from '../utils/utils';
+import * as utils from '../utils/utils';
+import {
+  AuthBackend,
+  AuthProviders,
+  AuthMethods,
+  OAuthCredentials,
+  OAuth1Credentials,
+  OAuth2Credentials,
+  AuthCredentials,
+  FirebaseAuthState,
+  AuthConfiguration,
+  FirebaseAuthDataAllProviders,
+  authDataToAuthState
+} from './auth_backend';
+
+const kBufferSize = 1;
+
+export const firebaseAuthConfig = (config: AuthConfiguration): Provider => {
+  return provide(FirebaseAuthConfig, {
+    useValue: config
+  });
+};
+
+@Injectable()
+export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
+  constructor(private _authBackend: AuthBackend,
+    @Optional() @Inject(FirebaseAuthConfig) private _config?: AuthConfiguration) {
+    super(kBufferSize);
+
+    this._authBackend.onAuth((authData) => this._emitAuthData(authData));
+  }
+
+  public login(config?: AuthConfiguration): Promise<FirebaseAuthState>;
+  public login(credentials?: FirebaseCredentials): Promise<FirebaseAuthState>;
+  public login(credentials: AuthCredentials, config?: AuthConfiguration): Promise<FirebaseAuthState>;
+  public login(obj1?: any, obj2?: AuthConfiguration): Promise<FirebaseAuthState> {
+    let config: AuthConfiguration = null;
+    let credentials: AuthCredentials = null;
+    if (arguments.length > 2) {
+      return this._reject('Login only accepts a maximum of two arguments.');
+    } else if (arguments.length == 2) {
+      credentials = obj1;
+      config = obj2;
+    } else if (arguments.length == 1) {
+      // Check if obj1 is password credentials
+      if (obj1.password && obj1.email) {
+        credentials = obj1;
+        config = {};
+      } else {
+        config = obj1;
+      }
+    }
+    config = this._mergeConfigs(config);
+
+    if (!isPresent(config.method)) {
+      return this._reject('You must provide a login method');
+    }
+    let providerMethods = [AuthMethods.Popup, AuthMethods.Redirect, AuthMethods.OAuthToken];
+    if (providerMethods.indexOf(config.method) != -1) {
+      if (!isPresent(config.provider)) {
+        return this._reject('You must include a provider to use this auth method.');
+      }
+    }
+    let credentialsMethods = [AuthMethods.Password, AuthMethods.OAuthToken, AuthMethods.CustomToken];
+    if (credentialsMethods.indexOf(config.method) != -1) {
+      if (!credentials) {
+        return this._reject('You must include credentials to use this auth method.');
+      }
+    }
+
+    switch (config.method) {
+      case AuthMethods.Popup:
+        return this._authBackend.authWithOAuthPopup(config.provider, this._scrubConfig(config));
+      case AuthMethods.Redirect:
+        return this._authBackend.authWithOAuthRedirect(config.provider, this._scrubConfig(config));
+      case AuthMethods.Anonymous:
+        return this._authBackend.authAnonymously(this._scrubConfig(config));
+      case AuthMethods.Password:
+        return this._authBackend.authWithPassword(<FirebaseCredentials>credentials, this._scrubConfig(config, false));
+      case AuthMethods.OAuthToken:
+        return this._authBackend.authWithOAuthToken(config.provider, <OAuthCredentials>credentials,
+          this._scrubConfig(config));
+      case AuthMethods.CustomToken:
+        return this._authBackend.authWithCustomToken((<OAuth2Credentials>credentials).token,
+          this._scrubConfig(config, false));
+    }
+  }
+
+  public logout(): void {
+    if (this._authBackend.getAuth() !== null) {
+      this._authBackend.unauth();
+    }
+  }
+
+  public getAuth(): FirebaseAuthData {
+    return this._authBackend.getAuth();
+  }
+
+  public createUser(credentials: FirebaseCredentials): Promise<FirebaseAuthData> {
+    return this._authBackend.createUser(credentials);
+  }
+
+  /**
+   * Merges the config object that is passed in with the configuration
+   * provided through DI. Giving precendence to the one that was passed.
+   */
+  private _mergeConfigs(config: AuthConfiguration): AuthConfiguration {
+    if (this._config == null)
+      return config;
+
+    return Object.assign({}, this._config, config);
+  }
+
+  private _reject(msg: string): Promise<FirebaseAuthState> {
+    return new Promise((res, rej) => {
+      return rej(msg);
+    });
+  }
+
+  private _scrubConfig(config: AuthConfiguration, scrubProvider = true): any {
+    let scrubbed = Object.assign({}, config);
+    if (scrubProvider) {
+      delete scrubbed.provider;
+    }
+    delete scrubbed.method;
+    return scrubbed;
+  }
+
+
+  private _emitAuthData(authData: FirebaseAuthDataAllProviders): void {
+    if (authData == null) {
+      this.next(null);
+    } else {
+      this.next(authDataToAuthState(authData));
+    }
+  }
+}

--- a/angularfire2/src/providers/auth_backend.ts
+++ b/angularfire2/src/providers/auth_backend.ts
@@ -1,0 +1,116 @@
+export abstract class AuthBackend {
+  abstract authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState>;
+  abstract authAnonymously(options?: any): Promise<FirebaseAuthState>;
+  abstract authWithPassword(credentials: FirebaseCredentials, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState>;
+  abstract authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+    : Promise<FirebaseAuthState>;
+  abstract onAuth(onComplete: (authData: FirebaseAuthData) => void): void;
+  abstract getAuth(): FirebaseAuthData;
+  abstract unauth(): void;
+  abstract createUser(credentials: FirebaseCredentials): Promise<FirebaseAuthData>;
+}
+
+// Firebase only provides typings for google
+export interface FirebaseAuthDataAllProviders extends FirebaseAuthData {
+  github?: any;
+  twitter?: any;
+  google?: any;
+  facebook?: any;
+  password?: any;
+  anonymous?: any;
+}
+
+export enum AuthProviders {
+  Github,
+  Twitter,
+  Facebook,
+  Google,
+  Password,
+  Anonymous,
+  Custom
+};
+
+export enum AuthMethods {
+  Popup,
+  Redirect,
+  Anonymous,
+  Password,
+  OAuthToken,
+  CustomToken
+};
+
+
+export interface AuthConfiguration {
+  method?: AuthMethods;
+  provider?: AuthProviders;
+  remember?: string;
+  scope?: string[];
+}
+
+export interface OAuth2Credentials {
+  token: string;
+}
+
+export interface OAuth1Credentials {
+  user_id: string;
+  oauth_token: string;
+  oauth_token_secret: string;
+}
+
+export type OAuthCredentials = OAuth1Credentials | OAuth2Credentials;
+
+export type AuthCredentials = FirebaseCredentials | OAuthCredentials;
+
+export interface FirebaseAuthState {
+  uid: string;
+  provider: AuthProviders;
+  auth: Object;
+  expires?: number;
+  github?: any;
+  google?: any;
+  twitter?: any;
+  facebook?: any;
+  password?: any;
+  anonymous?: any;
+}
+
+export function authDataToAuthState(authData: FirebaseAuthDataAllProviders): FirebaseAuthState {
+  let {auth, uid, provider, github, twitter, facebook, google, password, anonymous} = authData;
+  let authState: FirebaseAuthState = { auth, uid, expires: authData.expires, provider: null };
+  switch (provider) {
+    case 'github':
+      authState.github = github;
+      authState.provider = AuthProviders.Github;
+      break;
+    case 'twitter':
+      authState.twitter = twitter;
+      authState.provider = AuthProviders.Twitter;
+      break;
+    case 'facebook':
+      authState.facebook = facebook;
+      authState.provider = AuthProviders.Facebook;
+      break;
+    case 'google':
+      authState.google = google;
+      authState.provider = AuthProviders.Google;
+      break;
+    case 'password':
+      authState.password = password;
+      authState.provider = AuthProviders.Password;
+      break;
+    case 'anonymous':
+      authState.anonymous = anonymous;
+      authState.provider = AuthProviders.Anonymous;
+      break;
+    case 'custom':
+      authState.provider = AuthProviders.Custom;
+      break;
+    default:
+      throw new Error(`Unsupported firebase auth provider ${provider}`);
+  }
+
+  return authState;
+}
+

--- a/angularfire2/src/providers/firebase_sdk_auth_backend.ts
+++ b/angularfire2/src/providers/firebase_sdk_auth_backend.ts
@@ -1,0 +1,140 @@
+import {Injectable, Inject} from 'angular2/core';
+import {
+  AuthBackend,
+  FirebaseAuthState,
+  AuthProviders,
+  AuthMethods,
+  authDataToAuthState,
+  OAuth2Credentials,
+  OAuthCredentials
+} from './auth_backend';
+import {FirebaseRef} from '../tokens';
+import {isPresent} from '../utils/utils';
+import * as Firebase from 'firebase';
+
+@Injectable()
+export class FirebaseSdkAuthBackend extends AuthBackend {
+  constructor( @Inject(FirebaseRef) private _fbRef: Firebase,
+    private _webWorkerMode = false) {
+    super();
+  }
+
+  createUser(creds: FirebaseCredentials): Promise<FirebaseAuthData> {
+    return new Promise<FirebaseAuthData>((resolve, reject) => {
+      this._fbRef.createUser(creds, (err, authData) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(authData);
+        }
+      });
+    });
+  }
+
+  onAuth(onComplete: (authData: FirebaseAuthData) => void): void {
+    this._fbRef.onAuth(onComplete);
+  }
+
+  getAuth(): FirebaseAuthData {
+    return this._fbRef.getAuth();
+  }
+
+  unauth(): void {
+    this._fbRef.unauth();
+  }
+
+  authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(token, this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authAnonymously(options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authAnonymously(this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithPassword(credentials: FirebaseCredentials, options?: any)
+    : Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithPassword(credentials, this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithOAuthPopup(this._providerToString(provider),
+        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  /**
+   * Authenticates a Firebase client using a redirect-based OAuth flow
+   * NOTE: This promise will not be resolved if authentication is successful since the browser redirected.
+   * You should subscribe to the FirebaseAuth object to listen succesful login
+   */
+  authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      this._fbRef.authWithOAuthRedirect(this._providerToString(provider),
+        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+    : Promise<FirebaseAuthState> {
+    let p = new Promise((res, rej) => {
+      let credentials = isPresent((<OAuth2Credentials>credentialsObj).token)
+        ? (<OAuth2Credentials>credentialsObj).token
+        : credentialsObj;
+      this._fbRef.authWithOAuthToken(this._providerToString(provider), credentials,
+        this._handleFirebaseCb(res, rej, options), options);
+    });
+
+    return p;
+  }
+
+  private _handleFirebaseCb(res: Function, rej: Function, options: any): (err: any, auth?: FirebaseAuthData) => void {
+    return (err, auth?) => {
+      if (err) {
+        return rej(err);
+      } else {
+        if (!this._webWorkerMode)
+          return res(authDataToAuthState(auth));
+        else {
+          if (isPresent(options) && isPresent(options.remember)) {
+            // Add remember value in WebWorker mode so that the worker
+            // can auth with the same value
+            (<any>auth).remember = options.remember;
+          }
+          return res(auth);
+        }
+      }
+    };
+  }
+
+  private _providerToString(provider: AuthProviders): string {
+    switch (provider) {
+      case AuthProviders.Github:
+        return 'github';
+      case AuthProviders.Twitter:
+        return 'twitter';
+      case AuthProviders.Facebook:
+        return 'facebook';
+      case AuthProviders.Google:
+        return 'google';
+      default:
+        throw new Error(`Unsupported firebase auth provider ${provider}`);
+    }
+  }
+}

--- a/angularfire2/src/providers/web_workers/shared/channels.ts
+++ b/angularfire2/src/providers/web_workers/shared/channels.ts
@@ -1,0 +1,2 @@
+export const AUTH_CHANNEL = 'angularfire2-auth';
+export const INITIAL_AUTH_CHANNEL = 'angularfire2-auth-initial';

--- a/angularfire2/src/providers/web_workers/ui/auth.ts
+++ b/angularfire2/src/providers/web_workers/ui/auth.ts
@@ -1,0 +1,35 @@
+import {Injectable, Inject} from 'angular2/core';
+import {ServiceMessageBrokerFactory, PRIMITIVE} from 'angular2/platform/worker_render';
+import {AUTH_CHANNEL, INITIAL_AUTH_CHANNEL} from '../shared/channels';
+import {FirebaseRef} from '../../../tokens';
+import {FirebaseAuthState} from '../../auth_backend';
+import {FirebaseSdkAuthBackend} from '../../firebase_sdk_auth_backend';
+
+@Injectable()
+export class MessageBasedFirebaseAuth {
+  constructor(private _sdkBackend: FirebaseSdkAuthBackend,
+              private _brokerFactory: ServiceMessageBrokerFactory) {
+  }
+
+  start(): void {
+    let broker = this._brokerFactory.createMessageBroker(AUTH_CHANNEL);
+    broker.registerMethod('authAnonymously', [PRIMITIVE], this._sdkBackend.authAnonymously.bind(this._sdkBackend),
+                          PRIMITIVE);
+    broker.registerMethod('authWithPassword', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithPassword.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthPopup', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthPopup.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthRedirect', [PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthRedirect.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('authWithOAuthToken', [PRIMITIVE, PRIMITIVE, PRIMITIVE],
+                          this._sdkBackend.authWithOAuthToken.bind(this._sdkBackend), PRIMITIVE);
+    broker.registerMethod('getAuth', null, this._getAuth.bind(this), PRIMITIVE);
+    broker.registerMethod('unauth', null, this._sdkBackend.unauth.bind(this._sdkBackend));
+  }
+
+  private _getAuth(): Promise<FirebaseAuthData> {
+    return new Promise((res, rej) => {
+      res(this._sdkBackend.getAuth());
+    });
+  }
+}

--- a/angularfire2/src/providers/web_workers/worker/auth.ts
+++ b/angularfire2/src/providers/web_workers/worker/auth.ts
@@ -1,0 +1,147 @@
+import {Injectable, Inject} from 'angular2/core';
+
+// Import these from src/ until we have a specific import path for them
+// https://github.com/angular/angular/issues/7419
+import {
+  ClientMessageBrokerFactory,
+  ClientMessageBroker,
+  FnArg,
+  UiArguments
+} from 'angular2/src/web_workers/shared/client_message_broker';
+import {MessageBus} from 'angular2/src/web_workers/shared/message_bus';
+import {PRIMITIVE} from 'angular2/src/web_workers/shared/serializer';
+
+import {AUTH_CHANNEL, INITIAL_AUTH_CHANNEL} from '../shared/channels';
+import {FirebaseRef} from '../../../tokens';
+import {
+  AuthBackend,
+  FirebaseAuthState,
+  AuthProviders,
+  AuthMethods,
+  authDataToAuthState,
+  OAuth2Credentials,
+  OAuthCredentials
+} from '../../auth_backend';
+import {isPresent} from '../../../utils/utils';
+import * as Firebase from 'firebase';
+
+@Injectable()
+export class WebWorkerFirebaseAuth extends AuthBackend {
+  private _messageBroker: ClientMessageBroker;
+  private _authMetadata: {[key: string]: FirebaseAuthData} = {};
+  private _authCbs: Array<(authData: FirebaseAuthData) => void> = [];
+  private _gotAuth = false;
+
+  constructor (@Inject(FirebaseRef) private _fbRef: Firebase, brokerFactory: ClientMessageBrokerFactory,
+              bus: MessageBus) {
+    super();
+    this._messageBroker = brokerFactory.createMessageBroker(AUTH_CHANNEL);
+    let args = new UiArguments('getAuth');
+    this._messageBroker.runOnService(args, PRIMITIVE).then((authData: FirebaseAuthDataWithRemember) => {
+      this._gotAuth = true;
+      if (authData != null) {
+        this._handleAuthPromise(<FirebaseAuthDataWithRemember> authData);
+      }
+    });
+  }
+
+  onAuth (onComplete: (authData: FirebaseAuthData) => void): void {
+    this._fbRef.onAuth((authData) => {
+      if (!this._gotAuth) return false;
+      if (isPresent(authData) && isPresent(this._authMetadata[authData.token])) {
+        authData = this._authMetadata[authData.token];
+      }
+      onComplete(authData);
+    });
+  }
+
+  getAuth(): FirebaseAuthData {
+    return this._fbRef.getAuth();
+  }
+  
+  createUser(creds: FirebaseCredentials): Promise<FirebaseAuthData> {
+    return new Promise<FirebaseAuthData>((resolve, reject) => {
+      this._fbRef.createUser(creds, (err, authData) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(authData);
+        }
+      });
+    });
+  }
+
+  authAnonymously(options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authAnonymously', [new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+
+  authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
+    return new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(token, (err, authData) => {
+        if (err)
+          return rej(err);
+        else
+          return res(authDataToAuthState(authData));
+      });
+    });
+  }
+  authWithPassword(credentials: FirebaseCredentials, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithPassword',
+                               [new FnArg(credentials, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthPopup',
+                               [new FnArg(provider, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthRedirect',
+                               [new FnArg(provider, PRIMITIVE), new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+  authWithOAuthToken(provider: AuthProviders, credentialsObj: OAuthCredentials, options?: any)
+  : Promise<FirebaseAuthState> {
+    let args = new UiArguments('authWithOAuthToken',
+                               [new FnArg(provider, PRIMITIVE), 
+                                new FnArg(credentialsObj, PRIMITIVE),
+                                new FnArg(options, PRIMITIVE)]);
+    let uiAuthPromise = this._messageBroker.runOnService(args, PRIMITIVE);
+    return this._doAuth(uiAuthPromise);
+  }
+
+  unauth(): void {
+    let args = new UiArguments('unauth');
+    this._messageBroker.runOnService(args, null);
+    this._fbRef.unauth();
+  }
+
+  /**
+   * Performs custom token auth using the token returned from the UI.
+   * Saves the associated metatadata to be emited by onAuth.
+   */
+  private _doAuth(promise: Promise<FirebaseAuthDataWithRemember>): Promise<FirebaseAuthState> {
+    return promise.then((data) => this._handleAuthPromise(data));
+  }
+
+  private _handleAuthPromise(authData: FirebaseAuthDataWithRemember): Promise<FirebaseAuthState> {
+    this._authMetadata[authData.token] = authData;
+    return new Promise((res, rej) => {
+      this._fbRef.authWithCustomToken(authData.token, (err, _) => {
+        if (err)
+          return rej (err);
+        else 
+          return res(authDataToAuthState(authData));
+      }, {remember: authData.remember});
+    });
+  }
+}
+
+interface FirebaseAuthDataWithRemember extends FirebaseAuthData {
+  remember: string;
+}

--- a/angularfire2/src/tokens.ts
+++ b/angularfire2/src/tokens.ts
@@ -1,0 +1,5 @@
+import {OpaqueToken} from 'angular2/core';
+
+export const FirebaseUrl = new OpaqueToken('FirebaseUrl');
+export const FirebaseRef = new OpaqueToken('FirebaseRef')
+export const FirebaseAuthConfig = new OpaqueToken('FirebaseAuthConfig');

--- a/angularfire2/src/utils/absolute_path_resolver.spec.ts
+++ b/angularfire2/src/utils/absolute_path_resolver.spec.ts
@@ -1,0 +1,8 @@
+import {absolutePathResolver} from './absolute_path_resolver';
+describe('absolutePathResolver', () => {
+  it('should return fully qualified url for relative path', () => {
+    var root = 'https://angularfire2.firebaseio-demo.com/';
+    var path = '/questions';
+    expect(absolutePathResolver(root, path)).toBe(`${root}${path}`);
+  })
+});

--- a/angularfire2/src/utils/absolute_path_resolver.ts
+++ b/angularfire2/src/utils/absolute_path_resolver.ts
@@ -1,0 +1,3 @@
+export function absolutePathResolver (rootUrl:string, providedPath:string): string {
+  return providedPath.indexOf('/') === 0 ? `${rootUrl}${providedPath}` : providedPath;
+}

--- a/angularfire2/src/utils/firebase_list_factory.spec.ts
+++ b/angularfire2/src/utils/firebase_list_factory.spec.ts
@@ -1,0 +1,241 @@
+declare var require: any;
+import {
+  FirebaseListFactory,
+  onChildAdded,
+  onChildChanged,
+  onChildRemoved,
+  onChildUpdated,
+  unwrapMapFn
+} from './firebase_list_factory';
+import {FirebaseListObservable} from './firebase_list_observable';
+import {
+  beforeEach,
+  it,
+  iit,
+  ddescribe,
+  describe,
+  expect
+} from 'angular2/testing';
+import {Subscription} from 'rxjs';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/skip';
+import 'rxjs/add/operator/take';
+
+const rootFirebase = 'https://angularfire2-list-factory.firebaseio-demo.com/';
+
+describe('FirebaseListFactory', () => {
+  var subscription: Subscription;
+  var questions: FirebaseListObservable<any>;
+  var questionsSnapshotted: FirebaseListObservable<any>;
+  var ref: any;
+  var refSnapshotted: any;
+  var val1: any;
+  var val2: any;
+  var val3: any;
+
+  describe('constructor', () => {
+    
+    it('should accept a Firebase db url in the constructor', () => {
+      const list = FirebaseListFactory(`${rootFirebase}/questions`);
+      expect(list).toBeAnInstanceOf(FirebaseListObservable);
+    });
+    
+    it('should accept a Firebase db ref in the constructor', () => {
+      const list = FirebaseListFactory(new Firebase(`${rootFirebase}/questions`));
+      expect(list).toBeAnInstanceOf(FirebaseListObservable);
+    });    
+    
+  });
+
+  describe('methods', () => {
+
+    beforeEach((done: any) => {
+      val1 = { key: () => 'key1' };
+      val2 = { key: () => 'key2' };
+      val3 = { key: () => 'key3' };
+      (new Firebase(rootFirebase)).remove(done);
+      questions = FirebaseListFactory(`${rootFirebase}/questions`);
+      questionsSnapshotted = FirebaseListFactory(`${rootFirebase}/questionssnapshot`, { preserveSnapshot: true });
+      ref = (<any>questions)._ref;
+      refSnapshotted = (<any>questionsSnapshotted)._ref;
+    });
+
+    afterEach((done: any) => {
+      if (subscription && !subscription.isUnsubscribed) {
+        subscription.unsubscribe();
+      }
+      Promise.all([ref.remove(), refSnapshotted.remove()]).then(done, done.fail);
+    });
+
+
+    it('should emit only when the initial data set has been loaded', (done: any) => {
+      // TODO: Fix Firebase server event order. srsly
+      // Use set to populate and erase previous values
+      // Populate with mutliple values to see the initial data load
+      (<any>questions)._ref.set([{ initial1: true }, { initial2: true }, { initial3: true }, { initial4: true }])
+        .then(() => questions.take(1).toPromise())
+        .then((val: any[]) => {
+          expect(val.length).toBe(4);
+        })
+        .then(() => {
+          done();
+        }, done.fail);
+    });
+
+
+    it('should emit a new value when a child moves', (done: any) => {
+      subscription = questions
+        .skip(2)
+        .take(1)
+        .do((data: any) => {
+          expect(data.length).toBe(2);
+          expect(data[0].push2).toBe(true);
+          expect(data[1].push1).toBe(true);
+        })
+        .subscribe(() => {
+          done();
+        }, done.fail);
+
+      var child1 = ref.push({ push1: true }, () => {
+        ref.push({ push2: true }, () => {
+          child1.setPriority('ZZZZ')
+        });
+      });
+    });
+
+
+    it('should emit unwrapped data by default', (done: any) => {
+      ref.remove(() => {
+        ref.push({ unwrapped: true }, () => {
+          subscription = questions
+            .take(1)
+            .do((data: any) => {
+              expect(data.length).toBe(1);
+              expect(data[0].unwrapped).toBe(true);
+            })
+            .subscribe(() => {
+              done();
+            }, done.fail);
+        });
+      });
+    });
+
+
+    it('should emit snapshots if preserveSnapshot option is true', (done: any) => {
+      refSnapshotted.push('hello snapshot!', () => {
+        subscription = questionsSnapshotted
+          .take(1)
+          .do((data: any) => {
+            expect(data[0].val()).toEqual('hello snapshot!');
+          })
+          .subscribe(() => {
+            done();
+          }, done.fail);
+      });
+    });
+
+
+    it('should call off on all events when disposed', () => {
+      var firebaseSpy = spyOn(Firebase.prototype, 'off').and.callThrough();
+      subscription = FirebaseListFactory(rootFirebase).subscribe();
+      expect(firebaseSpy).not.toHaveBeenCalled();
+      subscription.unsubscribe();
+      expect(firebaseSpy).toHaveBeenCalled();
+    });
+
+
+    describe('onChildAdded', () => {
+      it('should add the child after the prevKey', () => {
+        expect(onChildAdded([val1, val2], val3, 'key1')).toEqual([val1, val3, val2]);
+      });
+
+
+      it('should not mutate the input array', () => {
+        var inputArr = [val1];
+        expect(onChildAdded(inputArr, val2, 'key1')).not.toEqual(inputArr);
+      });
+    });
+
+
+    describe('onChildChanged', () => {
+      it('should move the child after the specified prevKey', () => {
+        expect(onChildChanged([val1, val2], val1, 'key2')).toEqual([val2, val1]);
+      });
+
+
+      it('should move the child to the beginning if prevKey is null', () => {
+        expect(
+          onChildChanged([val1, val2, val3], val2, null)
+        ).toEqual([val2, val1, val3]);
+      });
+
+
+      it('should not mutate the input array', () => {
+        var inputArr = [val1, val2];
+        expect(onChildChanged(inputArr, val1, 'key2')).not.toEqual(inputArr);
+      });
+
+
+      it('should update the child', () => {
+        expect(
+          onChildUpdated([val1, val2, val3], {
+            key: () => 'newkey'
+          }, 'key1').map(v => v.key())
+        ).toEqual(['key1', 'newkey', 'key3']);
+      });
+    });
+
+
+    describe('onChildRemoved', () => {
+      var val1: any;
+      var val2: any;
+      var val3: any;
+
+      beforeEach(() => {
+        val1 = { key: () => 'key1' };
+        val2 = { key: () => 'key2' };
+        val3 = { key: () => 'key3' };
+      });
+
+
+      it('should remove the child', () => {
+        expect(
+          onChildRemoved([val1, val2, val3], val2)
+        ).toEqual([val1, val3]);
+      });
+    });
+
+
+    describe('unwrapMapFn', () => {
+      var val = { unwrapped: true };
+      var snapshot = {
+        key: () => 'key',
+        val: () => val
+      };
+
+      it('should return an object value with a $key property', () => {
+        expect(unwrapMapFn(snapshot as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          unwrapped: true
+        });
+      });
+
+
+      it('should return an object value with a $value property if value is scalar', () => {
+        expect(unwrapMapFn(Object.assign(snapshot, { val: () => 5 }) as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          $value: 5
+        });
+        expect(unwrapMapFn(Object.assign(snapshot, { val: () => false }) as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          $value: false
+        });
+        expect(unwrapMapFn(Object.assign(snapshot, { val: () => 'lol' }) as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          $value: 'lol'
+        });
+      });
+    });
+
+  });
+});

--- a/angularfire2/src/utils/firebase_list_factory.ts
+++ b/angularfire2/src/utils/firebase_list_factory.ts
@@ -1,0 +1,122 @@
+import {FirebaseListObservable, AFUnwrappedDataSnapshot} from './firebase_list_observable';
+import {Observer} from 'rxjs/Observer';
+import * as Firebase from 'firebase';
+import * as utils from './utils';
+
+export function FirebaseListFactory (absoluteUrlOrDbRef:string | Firebase, {preserveSnapshot}:FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
+  let ref: Firebase;
+  
+  utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
+    isUrl: () => ref = new Firebase(<string>absoluteUrlOrDbRef),
+    isRef: () => ref = <Firebase>absoluteUrlOrDbRef
+  });
+  
+  // if (utils.isString(absoluteUrlOrDbRef)) {  
+  //   ref = new Firebase(<string>absoluteUrlOrDbRef);
+  // } else {
+  //   ref = <Firebase>absoluteUrlOrDbRef;
+  // }
+  
+  return new FirebaseListObservable((obs:Observer<any[]>) => {
+    let arr:any[] = [];
+    let hasInitialLoad = false;
+
+    // The list should only emit after the initial load
+    // comes down from the Firebase database, (e.g.) all
+    // the initial child_added events have fired.
+    // This way a complete array is emitted which leads
+    // to better rendering performance
+    ref.once('value', (snap) => {
+      hasInitialLoad = true;
+      obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+    });
+
+    ref.on('child_added', (child:any, prevKey:string) => {
+      arr = onChildAdded(arr, child, prevKey);
+      // only emit the array after the initial load
+      if (hasInitialLoad) {
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
+    });
+
+    ref.on('child_removed', (child:any) => {
+      arr = onChildRemoved(arr, child)
+      if (hasInitialLoad) {
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
+    });
+
+    ref.on('child_changed', (child:any, prevKey: string) => {
+      arr = onChildChanged(arr, child, prevKey)
+      if (hasInitialLoad) {
+        // This also manages when the only change is prevKey change
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
+    });
+
+    return () => ref.off();
+  }, ref);
+}
+
+export interface FirebaseListFactoryOpts {
+  preserveSnapshot?: boolean;
+}
+
+export function unwrapMapFn (snapshot:FirebaseDataSnapshot): AFUnwrappedDataSnapshot {
+  var unwrapped = snapshot.val();
+  if ((/string|number|boolean/).test(typeof unwrapped)) {
+    unwrapped = {
+      $value: unwrapped
+    };
+  }
+  unwrapped.$key = snapshot.key();
+  return unwrapped;
+}
+
+export function onChildAdded(arr:any[], child:any, prevKey:string): any[] {
+  if (!arr.length) {
+    return [child];
+  }
+
+  return arr.reduce((accumulator:FirebaseDataSnapshot[], curr:FirebaseDataSnapshot, i:number) => {
+    if (!prevKey && i===0) {
+      accumulator.push(child);
+    }
+    accumulator.push(curr);
+    if (prevKey && prevKey === curr.key()) {
+      accumulator.push(child);
+    }
+    return accumulator;
+  }, []);
+}
+
+export function onChildChanged(arr:any[], child:any, prevKey:string): any[] {
+  return arr.reduce((accumulator:any[], val:any, i:number) => {
+    if (!prevKey && i==0) {
+      accumulator.push(child);
+      accumulator.push(val);
+    } else if(val.key() === prevKey) {
+      accumulator.push(val);
+      accumulator.push(child);
+    } else if (val.key() !== child.key()) {
+      accumulator.push(val);
+    }
+    return accumulator;
+  }, []);
+}
+
+export function onChildRemoved(arr:any[], child:any): any[] {
+  return arr.filter(c => c.key() !== child.key());
+}
+
+export function onChildUpdated(arr:any[], child:any, prevKey:string): any[] {
+  return arr.map((v, i, arr) => {
+    if(!prevKey && !i) {
+      return child;
+    } else if (i > 0 && arr[i-1].key() === prevKey) {
+      return child;
+    } else {
+      return v;
+    }
+  });
+}

--- a/angularfire2/src/utils/firebase_list_observable.spec.ts
+++ b/angularfire2/src/utils/firebase_list_observable.spec.ts
@@ -1,0 +1,227 @@
+import {describe,it,beforeEach} from 'angular2/testing';
+import {FirebaseListObservable} from './firebase_list_observable';
+import {Observer} from 'rxjs/Observer';
+import 'rxjs/add/operator/map';
+import * as Firebase from 'firebase';
+import {unwrapMapFn} from './firebase_list_factory';
+
+const rootUrl = 'https://angularfire2-list-obs.firebaseio-demo.com/';
+
+describe('FirebaseObservable', () => {
+  var O:FirebaseListObservable<any>;
+  var ref:Firebase;
+
+  beforeEach(() => {
+    ref = new Firebase(rootUrl);
+    O = new FirebaseListObservable((observer:Observer<any>) => {
+    }, ref);
+  });
+
+  afterEach((done:any) => {
+    ref.off();
+    ref.remove(done);
+  });
+
+
+  it('should return an instance of FirebaseObservable when calling operators', () => {
+    var O:FirebaseListObservable<number> = new FirebaseListObservable((observer:Observer<number>) => {
+    });
+    expect(O.map(noop) instanceof FirebaseListObservable).toBe(true);
+  });
+
+
+  describe('push', () => {
+    it('should throw an exception if pushed when not subscribed', () => {
+      O = new FirebaseListObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.push('foo');
+      }).toThrowError('No ref specified for this Observable!')
+    });
+
+
+    it('should call push on the underlying ref', () => {
+      var pushSpy = spyOn(ref, 'push');
+
+      O.subscribe();
+
+      O.push(1);
+
+      expect(pushSpy).toHaveBeenCalledWith(1);
+    });
+
+
+    it('should accept any type of value without compilation error', () => {
+      O.push('foo');
+    });
+
+
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.push('foo').then(done, done.fail);
+    });
+  });
+
+
+  describe('remove', () => {
+    var orphan = { orphan: true };
+    var child:Firebase;
+
+    beforeEach(() => {
+      child = ref.push(orphan);
+    });
+
+
+    it('should remove the item from the Firebase db when given the key', (done:any) => {
+      var childAddedSpy = jasmine.createSpy('childAdded');
+
+      ref.on('child_added', childAddedSpy);
+      O.remove(child.key())
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childAddedSpy.calls.argsFor(0)[0].val()).toEqual(orphan);
+          expect(data.val()).toBeNull();
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+
+    it('should remove the item from the Firebase db when given the reference', (done:any) => {
+      var childAddedSpy = jasmine.createSpy('childAdded');
+
+      ref.on('child_added', childAddedSpy);
+
+      O.remove(child)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childAddedSpy.calls.argsFor(0)[0].val()).toEqual(orphan);
+          expect(data.val()).toBeNull();
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+
+    it('should remove the item from the Firebase db when given the snapshot', (done:any) => {
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.remove(data)
+          .then(() => (<any>ref).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toBeNull();
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });
+
+
+    it('should remove the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.remove(unwrapMapFn(data))
+          .then(() => (<any>ref).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toBeNull();
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });
+    
+    it('should remove the whole list if no item is added', () => {
+      O.remove()
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(data.val()).toBe(null);
+        });
+    });
+
+
+    it('should throw an exception if input is not supported', () => {
+      var input = (<any>{lol:true});
+      expect(() => O.remove(input)).toThrowError(`FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: ${typeof input}`);
+    })
+  });
+  
+  describe('update', () => {
+    var orphan = { orphan: true };
+    var child:Firebase;
+
+    beforeEach(() => {
+      child = ref.push(orphan);
+    });    
+    
+    it('should update the item from the Firebase db when given the key', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child.key(), orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+    
+    it('should update the item from the Firebase db when given the reference', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child.ref(), orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });            
+
+    it('should update the item from the Firebase db when given the snapshot', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child, orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+    it('should update the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
+      const orphanChange = { changed: true }
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.update(unwrapMapFn(data), orphanChange)
+          .then(() => (<any>child).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toEqual({ 
+              orphan: true,
+              changed: true
+            });
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });        
+  
+  });
+  
+});
+
+function noop() {}

--- a/angularfire2/src/utils/firebase_list_observable.ts
+++ b/angularfire2/src/utils/firebase_list_observable.ts
@@ -1,0 +1,81 @@
+import {Observable} from 'rxjs/Observable';
+import {Operator} from 'rxjs/Operator';
+import {Subscriber} from 'rxjs/Subscriber';
+import {Subscription} from 'rxjs/Subscription';
+import * as utils from './utils';
+
+export type FirebaseOperation = string | Firebase | FirebaseDataSnapshot | AFUnwrappedDataSnapshot
+
+export interface FirebaseOperationCases {
+  stringCase: () => Promise<void>;
+  firebaseCase?: () => Promise<void>;
+  snapshotCase?: () => Promise<void>;
+  unwrappedSnapshotCase?: () => Promise<void>;
+}
+
+export class FirebaseListObservable<T> extends Observable<T> {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, private _ref?:Firebase) {
+    super(subscribe);
+  }
+  lift<T, R>(operator: Operator<T, R>): Observable<R> {
+    const observable = new FirebaseListObservable<R>();
+    observable.source = this;
+    observable.operator = operator;
+    observable._ref = this._ref;
+    return observable;
+  }
+
+  push(val:any):FirebaseWithPromise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.push(val);
+  }
+  
+  update(item: FirebaseOperation, value: Object): Promise<void> {
+    return this._checkOperationCases(item, {
+      stringCase: () => this._ref.child(<string>item).update(value),
+      firebaseCase: () => (<Firebase>item).update(value),
+      snapshotCase: () => (<FirebaseDataSnapshot>item).ref().update(value),
+      unwrappedSnapshotCase: () => this._ref.child((<AFUnwrappedDataSnapshot>item).$key).update(value)
+    });
+  }
+
+  remove(item:FirebaseOperation = null): Promise<void> {
+    // TODO: remove override when typings are updated to include
+    // remove() returning a promise.
+    
+    // if no item parameter is provided, remove the whole list
+    if (!item) {
+      return this._ref.remove();
+    }
+    return this._checkOperationCases(item, {
+      stringCase: () => this._ref.child(<string>item).remove(),
+      firebaseCase: () => (<Firebase>item).remove(),
+      snapshotCase: () => (<FirebaseDataSnapshot>item).ref().remove(),
+      unwrappedSnapshotCase: () => this._ref.child((<AFUnwrappedDataSnapshot>item).$key).remove()
+    });
+  }
+  
+  _checkOperationCases(item: FirebaseOperation, cases: FirebaseOperationCases) : Promise<void> {
+    if (utils.isString(item)) {
+      return cases.stringCase();
+    } else if (utils.isFirebaseRef(item)) {
+      // Firebase ref
+      return cases.firebaseCase();
+    } else if (utils.isFirebaseDataSnapshot(item)) {
+      // Snapshot
+      return cases.snapshotCase();
+    } else if (utils.isAFUnwrappedSnapshot(item)) {
+      // Unwrapped snapshot
+      return cases.unwrappedSnapshotCase()
+    }
+    throw new Error(`FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: ${typeof item}`);
+  }
+  
+}
+
+export interface AFUnwrappedDataSnapshot {
+  $key: string;
+  $value?: string | number | boolean;
+}

--- a/angularfire2/src/utils/firebase_object_factory.spec.ts
+++ b/angularfire2/src/utils/firebase_object_factory.spec.ts
@@ -1,0 +1,91 @@
+import {FirebaseObjectFactory} from '../utils/firebase_object_factory';
+import {FirebaseObjectObservable} from '../utils/firebase_object_observable';
+import {beforeEach, it, describe, expect} from 'angular2/testing';
+import {Subscription} from 'rxjs';
+
+const rootFirebase = 'https://angularfire2-object-factory.firebaseio-demo.com';
+
+describe('FirebaseObjectFactory', () => {
+  var i = 0;
+  var ref: Firebase;
+  var observable: FirebaseObjectObservable<any>;
+  var subscription: Subscription;
+  var nextSpy: jasmine.Spy;
+
+  describe('constructor', () => {
+
+    it('should accept a Firebase db url in the constructor', () => {
+      const object = FirebaseObjectFactory(`${rootFirebase}/questions`);
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
+
+    it('should accept a Firebase db ref in the constructor', () => {
+      const object = FirebaseObjectFactory(new Firebase(`${rootFirebase}/questions`));
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
+    
+    it('should accept a Firebase db query in the constructor', () => {
+      const object = FirebaseObjectFactory(new Firebase(`${rootFirebase}/questions`).orderByChild('unwrapped'));
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
+
+  });
+
+  describe('methods', () => {
+
+    beforeEach((done: any) => {
+      i = Date.now();
+      ref = new Firebase(`${rootFirebase}/questions/${i}`);
+      nextSpy = nextSpy = jasmine.createSpy('next');
+      observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`);
+      ref.remove(done);
+    });
+
+    afterEach(() => {
+      if (subscription && !subscription.isUnsubscribed) {
+        subscription.unsubscribe();
+      }
+    })
+
+
+    it('should emit a null value if no value is present when subscribed', (done: any) => {
+      subscription = observable.subscribe(val => {
+        expect(val).toBe(null);
+        done();
+      });
+    });
+
+
+    it('should emit unwrapped data by default', (done: any) => {
+      ref.set({ unwrapped: 'bar' }, () => {
+        subscription = observable.subscribe(val => {
+          if (!val) return
+          expect(val).toEqual({ unwrapped: 'bar' });
+          done();
+        });
+      });
+    });
+
+
+    it('should emit snapshots if preserveSnapshot option is true', (done: any) => {
+      observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`, { preserveSnapshot: true });
+      ref.remove(() => {
+        ref.set('preserved snapshot!', () => {
+          subscription = observable.subscribe(data => {
+            expect(data.val()).toEqual('preserved snapshot!');
+            done();
+          });
+        });
+      })
+    });
+
+
+    it('should call off on all events when disposed', () => {
+      var firebaseSpy = spyOn(Firebase.prototype, 'off');
+      subscription = FirebaseObjectFactory(rootFirebase).subscribe();
+      expect(firebaseSpy).not.toHaveBeenCalled();
+      subscription.unsubscribe();
+      expect(firebaseSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/angularfire2/src/utils/firebase_object_factory.ts
+++ b/angularfire2/src/utils/firebase_object_factory.ts
@@ -1,0 +1,24 @@
+import {FirebaseObjectObservable} from './firebase_object_observable';
+import {Observer} from 'rxjs/Observer';
+import * as Firebase from 'firebase';
+import * as utils from './utils';
+
+export function FirebaseObjectFactory (absoluteUrlOrDbRef:string | Firebase | FirebaseQuery, {preserveSnapshot}:FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
+  let ref: Firebase;
+  utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
+    isUrl: () => ref = new Firebase(<string>absoluteUrlOrDbRef),
+    isRef: () => ref = <Firebase>absoluteUrlOrDbRef
+  });
+  
+  return new FirebaseObjectObservable((obs:Observer<any[]>) => {
+    ref.on('value', (snapshot) => {
+      obs.next(preserveSnapshot ? snapshot : snapshot.val())
+    });
+
+    return () => ref.off();
+  }, ref);
+}
+
+export interface FirebaseObjectFactoryOpts {
+  preserveSnapshot?: boolean;
+}

--- a/angularfire2/src/utils/firebase_object_observable.spec.ts
+++ b/angularfire2/src/utils/firebase_object_observable.spec.ts
@@ -1,0 +1,116 @@
+import {describe,it,beforeEach} from 'angular2/testing';
+import {FirebaseObjectObservable} from './firebase_object_observable';
+import {Observer} from 'rxjs/Observer';
+import 'rxjs/add/operator/map';
+import * as Firebase from 'firebase';
+
+const rootUrl = 'https://angularfire2-obj-obs.firebaseio-demo.com/';
+
+describe('FirebaseObjectObservable', () => {
+  
+  var O:FirebaseObjectObservable<any>;
+  var ref:Firebase;
+
+  beforeEach(() => {
+    ref = new Firebase(rootUrl);
+    O = new FirebaseObjectObservable((observer:Observer<any>) => {
+    }, ref);
+  });
+
+  afterEach((done:any) => {
+    ref.off();
+    ref.remove();
+    done();
+  });
+  
+  it('should return an instance of FirebaseObservable when calling operators', () => {
+    var O:FirebaseObjectObservable<number> = new FirebaseObjectObservable((observer:Observer<number>) => {
+    });
+    expect(O.map(noop) instanceof FirebaseObjectObservable).toBe(true);
+  });
+  
+  describe('set', () => {
+    
+    it('should call set on the underlying ref', (done:any) => {
+      var setSpy = spyOn(ref, 'set');
+
+      O.subscribe();
+      O.set(1);
+      expect(setSpy).toHaveBeenCalledWith(1);
+      done();
+    });    
+    
+    it('should throw an exception if set when not subscribed', () => {
+      O = new FirebaseObjectObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.set('foo');
+      }).toThrowError('No ref specified for this Observable!')
+    });
+    
+    it('should accept any type of value without compilation error', () => {
+      O.set('foo');
+    });
+
+
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.set('foo').then(done, done.fail);
+    });        
+    
+  });
+  
+  describe('update', () => {
+    const updateObject = { hot: 'firebae' };
+    it('should call update on the underlying ref', () => {
+      var updateSpy = spyOn(ref, 'update');
+
+      O.subscribe();
+      O.update(updateObject);
+      expect(updateSpy).toHaveBeenCalledWith(updateObject);
+    });    
+    
+    it('should throw an exception if updated when not subscribed', () => {
+      O = new FirebaseObjectObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.update(updateObject);
+      }).toThrowError('No ref specified for this Observable!')
+    });
+    
+    it('should accept any type of value without compilation error', () => {
+      O.update(updateObject);
+    });
+
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.update(updateObject).then(done, done.fail);
+    });        
+    
+  });  
+
+  describe('remove', () => {
+
+    it('should call remove on the underlying ref', () => {
+      var removeSpy = spyOn(ref, 'remove');
+
+      O.subscribe();
+      O.remove();
+      expect(removeSpy).toHaveBeenCalledWith();
+    });    
+    
+    it('should throw an exception if removed when not subscribed', () => {
+      O = new FirebaseObjectObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.remove();
+      }).toThrowError('No ref specified for this Observable!')
+    });
+    
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.remove().then(done, done.fail);
+    });        
+    
+  }); 
+  
+});
+
+function noop() {}

--- a/angularfire2/src/utils/firebase_object_observable.ts
+++ b/angularfire2/src/utils/firebase_object_observable.ts
@@ -1,0 +1,35 @@
+import {Observable} from 'rxjs/Observable';
+import {Operator} from 'rxjs/Operator';
+import {Subscriber} from 'rxjs/Subscriber';
+import {Subscription} from 'rxjs/Subscription';
+
+export class FirebaseObjectObservable<T> extends Observable<T> {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, private _ref?:Firebase) {
+    super(subscribe);
+  }
+  lift<T, R>(operator: Operator<T, R>): Observable<R> {
+    const observable = new FirebaseObjectObservable<R>();
+    observable.source = this;
+    observable.operator = operator;
+    observable._ref = this._ref;
+    return observable;
+  }
+  set(value: any): Promise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.set(value);
+  }
+  update(value: Object): Promise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.update(value);
+  }
+  remove(): Promise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.remove();
+  }
+}

--- a/angularfire2/src/utils/utils.ts
+++ b/angularfire2/src/utils/utils.ts
@@ -1,0 +1,41 @@
+export function isPresent(obj: any): boolean {
+  return obj !== undefined && obj !== null;
+}
+
+export function isString(value: any): boolean {
+  return typeof value === 'string';
+}
+
+export function isFirebaseRef(value: any): boolean {  
+  return value instanceof Firebase;
+}
+
+export function isFirebaseQuery(value: any): boolean {
+  return typeof value.orderByChild === 'function';
+}
+
+export function isFirebaseDataSnapshot(value: any): boolean {
+  return typeof value.key === 'function';
+}
+
+export function isAFUnwrappedSnapshot(value: any): boolean {
+  return typeof value.$key === 'string';
+}
+
+export interface CheckUrlRef {
+  isUrl: () => any;
+  isRef: () => any;
+}
+
+export function checkForUrlOrFirebaseRef(urlOrRef: string | Firebase | FirebaseQuery, cases: CheckUrlRef): any {
+  if (isString(urlOrRef)) {
+    return cases.isUrl();
+  }
+  if (isFirebaseRef(urlOrRef)) {
+    return cases.isRef();
+  }
+  if (isFirebaseQuery(urlOrRef)) {
+    return cases.isRef();
+  }
+  throw new Error('Provide a url or a Firebase database reference');  
+}

--- a/angularfire2/tokens.js
+++ b/angularfire2/tokens.js
@@ -1,0 +1,15 @@
+System.register(['angular2/core'], function(exports_1) {
+    var core_1;
+    var FirebaseUrl, FirebaseRef, FirebaseAuthConfig;
+    return {
+        setters:[
+            function (core_1_1) {
+                core_1 = core_1_1;
+            }],
+        execute: function() {
+            exports_1("FirebaseUrl", FirebaseUrl = new core_1.OpaqueToken('FirebaseUrl'));
+            exports_1("FirebaseRef", FirebaseRef = new core_1.OpaqueToken('FirebaseRef'));
+            exports_1("FirebaseAuthConfig", FirebaseAuthConfig = new core_1.OpaqueToken('FirebaseAuthConfig'));
+        }
+    }
+});

--- a/angularfire2/tokens.ts
+++ b/angularfire2/tokens.ts
@@ -1,0 +1,5 @@
+import {OpaqueToken} from 'angular2/core';
+
+export const FirebaseUrl = new OpaqueToken('FirebaseUrl');
+export const FirebaseRef = new OpaqueToken('FirebaseRef')
+export const FirebaseAuthConfig = new OpaqueToken('FirebaseAuthConfig');

--- a/angularfire2/utils/absolute_path_resolver.spec.ts
+++ b/angularfire2/utils/absolute_path_resolver.spec.ts
@@ -1,0 +1,8 @@
+import {absolutePathResolver} from './absolute_path_resolver';
+describe('absolutePathResolver', () => {
+  it('should return fully qualified url for relative path', () => {
+    var root = 'https://angularfire2.firebaseio-demo.com/';
+    var path = '/questions';
+    expect(absolutePathResolver(root, path)).toBe(`${root}${path}`);
+  })
+});

--- a/angularfire2/utils/absolute_path_resolver.ts
+++ b/angularfire2/utils/absolute_path_resolver.ts
@@ -1,0 +1,3 @@
+export function absolutePathResolver (rootUrl:string, providedPath:string): string {
+  return providedPath.indexOf('/') === 0 ? `${rootUrl}${providedPath}` : providedPath;
+}

--- a/angularfire2/utils/firebase_list_factory.js
+++ b/angularfire2/utils/firebase_list_factory.js
@@ -1,0 +1,127 @@
+System.register(['./firebase_list_observable', 'firebase', './utils'], function(exports_1) {
+    var firebase_list_observable_1, Firebase, utils;
+    function FirebaseListFactory(absoluteUrlOrDbRef, _a) {
+        var preserveSnapshot = (_a === void 0 ? {} : _a).preserveSnapshot;
+        var ref;
+        utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
+            isUrl: function () { return ref = new Firebase(absoluteUrlOrDbRef); },
+            isRef: function () { return ref = absoluteUrlOrDbRef; }
+        });
+        // if (utils.isString(absoluteUrlOrDbRef)) {  
+        //   ref = new Firebase(<string>absoluteUrlOrDbRef);
+        // } else {
+        //   ref = <Firebase>absoluteUrlOrDbRef;
+        // }
+        return new firebase_list_observable_1.FirebaseListObservable(function (obs) {
+            var arr = [];
+            var hasInitialLoad = false;
+            // The list should only emit after the initial load
+            // comes down from the Firebase database, (e.g.) all
+            // the initial child_added events have fired.
+            // This way a complete array is emitted which leads
+            // to better rendering performance
+            ref.once('value', function (snap) {
+                hasInitialLoad = true;
+                obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+            });
+            ref.on('child_added', function (child, prevKey) {
+                arr = onChildAdded(arr, child, prevKey);
+                // only emit the array after the initial load
+                if (hasInitialLoad) {
+                    obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+                }
+            });
+            ref.on('child_removed', function (child) {
+                arr = onChildRemoved(arr, child);
+                if (hasInitialLoad) {
+                    obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+                }
+            });
+            ref.on('child_changed', function (child, prevKey) {
+                arr = onChildChanged(arr, child, prevKey);
+                if (hasInitialLoad) {
+                    // This also manages when the only change is prevKey change
+                    obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+                }
+            });
+            return function () { return ref.off(); };
+        }, ref);
+    }
+    exports_1("FirebaseListFactory", FirebaseListFactory);
+    function unwrapMapFn(snapshot) {
+        var unwrapped = snapshot.val();
+        if ((/string|number|boolean/).test(typeof unwrapped)) {
+            unwrapped = {
+                $value: unwrapped
+            };
+        }
+        unwrapped.$key = snapshot.key();
+        return unwrapped;
+    }
+    exports_1("unwrapMapFn", unwrapMapFn);
+    function onChildAdded(arr, child, prevKey) {
+        if (!arr.length) {
+            return [child];
+        }
+        return arr.reduce(function (accumulator, curr, i) {
+            if (!prevKey && i === 0) {
+                accumulator.push(child);
+            }
+            accumulator.push(curr);
+            if (prevKey && prevKey === curr.key()) {
+                accumulator.push(child);
+            }
+            return accumulator;
+        }, []);
+    }
+    exports_1("onChildAdded", onChildAdded);
+    function onChildChanged(arr, child, prevKey) {
+        return arr.reduce(function (accumulator, val, i) {
+            if (!prevKey && i == 0) {
+                accumulator.push(child);
+                accumulator.push(val);
+            }
+            else if (val.key() === prevKey) {
+                accumulator.push(val);
+                accumulator.push(child);
+            }
+            else if (val.key() !== child.key()) {
+                accumulator.push(val);
+            }
+            return accumulator;
+        }, []);
+    }
+    exports_1("onChildChanged", onChildChanged);
+    function onChildRemoved(arr, child) {
+        return arr.filter(function (c) { return c.key() !== child.key(); });
+    }
+    exports_1("onChildRemoved", onChildRemoved);
+    function onChildUpdated(arr, child, prevKey) {
+        return arr.map(function (v, i, arr) {
+            if (!prevKey && !i) {
+                return child;
+            }
+            else if (i > 0 && arr[i - 1].key() === prevKey) {
+                return child;
+            }
+            else {
+                return v;
+            }
+        });
+    }
+    exports_1("onChildUpdated", onChildUpdated);
+    return {
+        setters:[
+            function (firebase_list_observable_1_1) {
+                firebase_list_observable_1 = firebase_list_observable_1_1;
+            },
+            function (Firebase_1) {
+                Firebase = Firebase_1;
+            },
+            function (utils_1) {
+                utils = utils_1;
+            }],
+        execute: function() {
+        }
+    }
+});

--- a/angularfire2/utils/firebase_list_factory.spec.ts
+++ b/angularfire2/utils/firebase_list_factory.spec.ts
@@ -1,0 +1,241 @@
+declare var require: any;
+import {
+  FirebaseListFactory,
+  onChildAdded,
+  onChildChanged,
+  onChildRemoved,
+  onChildUpdated,
+  unwrapMapFn
+} from './firebase_list_factory';
+import {FirebaseListObservable} from './firebase_list_observable';
+import {
+  beforeEach,
+  it,
+  iit,
+  ddescribe,
+  describe,
+  expect
+} from 'angular2/testing';
+import {Subscription} from 'rxjs';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/skip';
+import 'rxjs/add/operator/take';
+
+const rootFirebase = 'https://angularfire2-list-factory.firebaseio-demo.com/';
+
+describe('FirebaseListFactory', () => {
+  var subscription: Subscription;
+  var questions: FirebaseListObservable<any>;
+  var questionsSnapshotted: FirebaseListObservable<any>;
+  var ref: any;
+  var refSnapshotted: any;
+  var val1: any;
+  var val2: any;
+  var val3: any;
+
+  describe('constructor', () => {
+    
+    it('should accept a Firebase db url in the constructor', () => {
+      const list = FirebaseListFactory(`${rootFirebase}/questions`);
+      expect(list).toBeAnInstanceOf(FirebaseListObservable);
+    });
+    
+    it('should accept a Firebase db ref in the constructor', () => {
+      const list = FirebaseListFactory(new Firebase(`${rootFirebase}/questions`));
+      expect(list).toBeAnInstanceOf(FirebaseListObservable);
+    });    
+    
+  });
+
+  describe('methods', () => {
+
+    beforeEach((done: any) => {
+      val1 = { key: () => 'key1' };
+      val2 = { key: () => 'key2' };
+      val3 = { key: () => 'key3' };
+      (new Firebase(rootFirebase)).remove(done);
+      questions = FirebaseListFactory(`${rootFirebase}/questions`);
+      questionsSnapshotted = FirebaseListFactory(`${rootFirebase}/questionssnapshot`, { preserveSnapshot: true });
+      ref = (<any>questions)._ref;
+      refSnapshotted = (<any>questionsSnapshotted)._ref;
+    });
+
+    afterEach((done: any) => {
+      if (subscription && !subscription.isUnsubscribed) {
+        subscription.unsubscribe();
+      }
+      Promise.all([ref.remove(), refSnapshotted.remove()]).then(done, done.fail);
+    });
+
+
+    it('should emit only when the initial data set has been loaded', (done: any) => {
+      // TODO: Fix Firebase server event order. srsly
+      // Use set to populate and erase previous values
+      // Populate with mutliple values to see the initial data load
+      (<any>questions)._ref.set([{ initial1: true }, { initial2: true }, { initial3: true }, { initial4: true }])
+        .then(() => questions.take(1).toPromise())
+        .then((val: any[]) => {
+          expect(val.length).toBe(4);
+        })
+        .then(() => {
+          done();
+        }, done.fail);
+    });
+
+
+    it('should emit a new value when a child moves', (done: any) => {
+      subscription = questions
+        .skip(2)
+        .take(1)
+        .do((data: any) => {
+          expect(data.length).toBe(2);
+          expect(data[0].push2).toBe(true);
+          expect(data[1].push1).toBe(true);
+        })
+        .subscribe(() => {
+          done();
+        }, done.fail);
+
+      var child1 = ref.push({ push1: true }, () => {
+        ref.push({ push2: true }, () => {
+          child1.setPriority('ZZZZ')
+        });
+      });
+    });
+
+
+    it('should emit unwrapped data by default', (done: any) => {
+      ref.remove(() => {
+        ref.push({ unwrapped: true }, () => {
+          subscription = questions
+            .take(1)
+            .do((data: any) => {
+              expect(data.length).toBe(1);
+              expect(data[0].unwrapped).toBe(true);
+            })
+            .subscribe(() => {
+              done();
+            }, done.fail);
+        });
+      });
+    });
+
+
+    it('should emit snapshots if preserveSnapshot option is true', (done: any) => {
+      refSnapshotted.push('hello snapshot!', () => {
+        subscription = questionsSnapshotted
+          .take(1)
+          .do((data: any) => {
+            expect(data[0].val()).toEqual('hello snapshot!');
+          })
+          .subscribe(() => {
+            done();
+          }, done.fail);
+      });
+    });
+
+
+    it('should call off on all events when disposed', () => {
+      var firebaseSpy = spyOn(Firebase.prototype, 'off').and.callThrough();
+      subscription = FirebaseListFactory(rootFirebase).subscribe();
+      expect(firebaseSpy).not.toHaveBeenCalled();
+      subscription.unsubscribe();
+      expect(firebaseSpy).toHaveBeenCalled();
+    });
+
+
+    describe('onChildAdded', () => {
+      it('should add the child after the prevKey', () => {
+        expect(onChildAdded([val1, val2], val3, 'key1')).toEqual([val1, val3, val2]);
+      });
+
+
+      it('should not mutate the input array', () => {
+        var inputArr = [val1];
+        expect(onChildAdded(inputArr, val2, 'key1')).not.toEqual(inputArr);
+      });
+    });
+
+
+    describe('onChildChanged', () => {
+      it('should move the child after the specified prevKey', () => {
+        expect(onChildChanged([val1, val2], val1, 'key2')).toEqual([val2, val1]);
+      });
+
+
+      it('should move the child to the beginning if prevKey is null', () => {
+        expect(
+          onChildChanged([val1, val2, val3], val2, null)
+        ).toEqual([val2, val1, val3]);
+      });
+
+
+      it('should not mutate the input array', () => {
+        var inputArr = [val1, val2];
+        expect(onChildChanged(inputArr, val1, 'key2')).not.toEqual(inputArr);
+      });
+
+
+      it('should update the child', () => {
+        expect(
+          onChildUpdated([val1, val2, val3], {
+            key: () => 'newkey'
+          }, 'key1').map(v => v.key())
+        ).toEqual(['key1', 'newkey', 'key3']);
+      });
+    });
+
+
+    describe('onChildRemoved', () => {
+      var val1: any;
+      var val2: any;
+      var val3: any;
+
+      beforeEach(() => {
+        val1 = { key: () => 'key1' };
+        val2 = { key: () => 'key2' };
+        val3 = { key: () => 'key3' };
+      });
+
+
+      it('should remove the child', () => {
+        expect(
+          onChildRemoved([val1, val2, val3], val2)
+        ).toEqual([val1, val3]);
+      });
+    });
+
+
+    describe('unwrapMapFn', () => {
+      var val = { unwrapped: true };
+      var snapshot = {
+        key: () => 'key',
+        val: () => val
+      };
+
+      it('should return an object value with a $key property', () => {
+        expect(unwrapMapFn(snapshot as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          unwrapped: true
+        });
+      });
+
+
+      it('should return an object value with a $value property if value is scalar', () => {
+        expect(unwrapMapFn(Object.assign(snapshot, { val: () => 5 }) as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          $value: 5
+        });
+        expect(unwrapMapFn(Object.assign(snapshot, { val: () => false }) as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          $value: false
+        });
+        expect(unwrapMapFn(Object.assign(snapshot, { val: () => 'lol' }) as FirebaseDataSnapshot)).toEqual({
+          $key: 'key',
+          $value: 'lol'
+        });
+      });
+    });
+
+  });
+});

--- a/angularfire2/utils/firebase_list_factory.ts
+++ b/angularfire2/utils/firebase_list_factory.ts
@@ -1,0 +1,122 @@
+import {FirebaseListObservable, AFUnwrappedDataSnapshot} from './firebase_list_observable';
+import {Observer} from 'rxjs/Observer';
+import * as Firebase from 'firebase';
+import * as utils from './utils';
+
+export function FirebaseListFactory (absoluteUrlOrDbRef:string | Firebase, {preserveSnapshot}:FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
+  let ref: Firebase;
+  
+  utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
+    isUrl: () => ref = new Firebase(<string>absoluteUrlOrDbRef),
+    isRef: () => ref = <Firebase>absoluteUrlOrDbRef
+  });
+  
+  // if (utils.isString(absoluteUrlOrDbRef)) {  
+  //   ref = new Firebase(<string>absoluteUrlOrDbRef);
+  // } else {
+  //   ref = <Firebase>absoluteUrlOrDbRef;
+  // }
+  
+  return new FirebaseListObservable((obs:Observer<any[]>) => {
+    let arr:any[] = [];
+    let hasInitialLoad = false;
+
+    // The list should only emit after the initial load
+    // comes down from the Firebase database, (e.g.) all
+    // the initial child_added events have fired.
+    // This way a complete array is emitted which leads
+    // to better rendering performance
+    ref.once('value', (snap) => {
+      hasInitialLoad = true;
+      obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+    });
+
+    ref.on('child_added', (child:any, prevKey:string) => {
+      arr = onChildAdded(arr, child, prevKey);
+      // only emit the array after the initial load
+      if (hasInitialLoad) {
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
+    });
+
+    ref.on('child_removed', (child:any) => {
+      arr = onChildRemoved(arr, child)
+      if (hasInitialLoad) {
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
+    });
+
+    ref.on('child_changed', (child:any, prevKey: string) => {
+      arr = onChildChanged(arr, child, prevKey)
+      if (hasInitialLoad) {
+        // This also manages when the only change is prevKey change
+        obs.next(preserveSnapshot ? arr : arr.map(unwrapMapFn));
+      }
+    });
+
+    return () => ref.off();
+  }, ref);
+}
+
+export interface FirebaseListFactoryOpts {
+  preserveSnapshot?: boolean;
+}
+
+export function unwrapMapFn (snapshot:FirebaseDataSnapshot): AFUnwrappedDataSnapshot {
+  var unwrapped = snapshot.val();
+  if ((/string|number|boolean/).test(typeof unwrapped)) {
+    unwrapped = {
+      $value: unwrapped
+    };
+  }
+  unwrapped.$key = snapshot.key();
+  return unwrapped;
+}
+
+export function onChildAdded(arr:any[], child:any, prevKey:string): any[] {
+  if (!arr.length) {
+    return [child];
+  }
+
+  return arr.reduce((accumulator:FirebaseDataSnapshot[], curr:FirebaseDataSnapshot, i:number) => {
+    if (!prevKey && i===0) {
+      accumulator.push(child);
+    }
+    accumulator.push(curr);
+    if (prevKey && prevKey === curr.key()) {
+      accumulator.push(child);
+    }
+    return accumulator;
+  }, []);
+}
+
+export function onChildChanged(arr:any[], child:any, prevKey:string): any[] {
+  return arr.reduce((accumulator:any[], val:any, i:number) => {
+    if (!prevKey && i==0) {
+      accumulator.push(child);
+      accumulator.push(val);
+    } else if(val.key() === prevKey) {
+      accumulator.push(val);
+      accumulator.push(child);
+    } else if (val.key() !== child.key()) {
+      accumulator.push(val);
+    }
+    return accumulator;
+  }, []);
+}
+
+export function onChildRemoved(arr:any[], child:any): any[] {
+  return arr.filter(c => c.key() !== child.key());
+}
+
+export function onChildUpdated(arr:any[], child:any, prevKey:string): any[] {
+  return arr.map((v, i, arr) => {
+    if(!prevKey && !i) {
+      return child;
+    } else if (i > 0 && arr[i-1].key() === prevKey) {
+      return child;
+    } else {
+      return v;
+    }
+  });
+}

--- a/angularfire2/utils/firebase_list_observable.js
+++ b/angularfire2/utils/firebase_list_observable.js
@@ -1,0 +1,85 @@
+System.register(['rxjs/Observable', './utils'], function(exports_1) {
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var Observable_1, utils;
+    var FirebaseListObservable;
+    return {
+        setters:[
+            function (Observable_1_1) {
+                Observable_1 = Observable_1_1;
+            },
+            function (utils_1) {
+                utils = utils_1;
+            }],
+        execute: function() {
+            FirebaseListObservable = (function (_super) {
+                __extends(FirebaseListObservable, _super);
+                function FirebaseListObservable(subscribe, _ref) {
+                    _super.call(this, subscribe);
+                    this._ref = _ref;
+                }
+                FirebaseListObservable.prototype.lift = function (operator) {
+                    var observable = new FirebaseListObservable();
+                    observable.source = this;
+                    observable.operator = operator;
+                    observable._ref = this._ref;
+                    return observable;
+                };
+                FirebaseListObservable.prototype.push = function (val) {
+                    if (!this._ref) {
+                        throw new Error('No ref specified for this Observable!');
+                    }
+                    return this._ref.push(val);
+                };
+                FirebaseListObservable.prototype.update = function (item, value) {
+                    var _this = this;
+                    return this._checkOperationCases(item, {
+                        stringCase: function () { return _this._ref.child(item).update(value); },
+                        firebaseCase: function () { return item.update(value); },
+                        snapshotCase: function () { return item.ref().update(value); },
+                        unwrappedSnapshotCase: function () { return _this._ref.child(item.$key).update(value); }
+                    });
+                };
+                FirebaseListObservable.prototype.remove = function (item) {
+                    // TODO: remove override when typings are updated to include
+                    // remove() returning a promise.
+                    var _this = this;
+                    if (item === void 0) { item = null; }
+                    // if no item parameter is provided, remove the whole list
+                    if (!item) {
+                        return this._ref.remove();
+                    }
+                    return this._checkOperationCases(item, {
+                        stringCase: function () { return _this._ref.child(item).remove(); },
+                        firebaseCase: function () { return item.remove(); },
+                        snapshotCase: function () { return item.ref().remove(); },
+                        unwrappedSnapshotCase: function () { return _this._ref.child(item.$key).remove(); }
+                    });
+                };
+                FirebaseListObservable.prototype._checkOperationCases = function (item, cases) {
+                    if (utils.isString(item)) {
+                        return cases.stringCase();
+                    }
+                    else if (utils.isFirebaseRef(item)) {
+                        // Firebase ref
+                        return cases.firebaseCase();
+                    }
+                    else if (utils.isFirebaseDataSnapshot(item)) {
+                        // Snapshot
+                        return cases.snapshotCase();
+                    }
+                    else if (utils.isAFUnwrappedSnapshot(item)) {
+                        // Unwrapped snapshot
+                        return cases.unwrappedSnapshotCase();
+                    }
+                    throw new Error("FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: " + typeof item);
+                };
+                return FirebaseListObservable;
+            })(Observable_1.Observable);
+            exports_1("FirebaseListObservable", FirebaseListObservable);
+        }
+    }
+});

--- a/angularfire2/utils/firebase_list_observable.spec.ts
+++ b/angularfire2/utils/firebase_list_observable.spec.ts
@@ -1,0 +1,227 @@
+import {describe,it,beforeEach} from 'angular2/testing';
+import {FirebaseListObservable} from './firebase_list_observable';
+import {Observer} from 'rxjs/Observer';
+import 'rxjs/add/operator/map';
+import * as Firebase from 'firebase';
+import {unwrapMapFn} from './firebase_list_factory';
+
+const rootUrl = 'https://angularfire2-list-obs.firebaseio-demo.com/';
+
+describe('FirebaseObservable', () => {
+  var O:FirebaseListObservable<any>;
+  var ref:Firebase;
+
+  beforeEach(() => {
+    ref = new Firebase(rootUrl);
+    O = new FirebaseListObservable((observer:Observer<any>) => {
+    }, ref);
+  });
+
+  afterEach((done:any) => {
+    ref.off();
+    ref.remove(done);
+  });
+
+
+  it('should return an instance of FirebaseObservable when calling operators', () => {
+    var O:FirebaseListObservable<number> = new FirebaseListObservable((observer:Observer<number>) => {
+    });
+    expect(O.map(noop) instanceof FirebaseListObservable).toBe(true);
+  });
+
+
+  describe('push', () => {
+    it('should throw an exception if pushed when not subscribed', () => {
+      O = new FirebaseListObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.push('foo');
+      }).toThrowError('No ref specified for this Observable!')
+    });
+
+
+    it('should call push on the underlying ref', () => {
+      var pushSpy = spyOn(ref, 'push');
+
+      O.subscribe();
+
+      O.push(1);
+
+      expect(pushSpy).toHaveBeenCalledWith(1);
+    });
+
+
+    it('should accept any type of value without compilation error', () => {
+      O.push('foo');
+    });
+
+
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.push('foo').then(done, done.fail);
+    });
+  });
+
+
+  describe('remove', () => {
+    var orphan = { orphan: true };
+    var child:Firebase;
+
+    beforeEach(() => {
+      child = ref.push(orphan);
+    });
+
+
+    it('should remove the item from the Firebase db when given the key', (done:any) => {
+      var childAddedSpy = jasmine.createSpy('childAdded');
+
+      ref.on('child_added', childAddedSpy);
+      O.remove(child.key())
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childAddedSpy.calls.argsFor(0)[0].val()).toEqual(orphan);
+          expect(data.val()).toBeNull();
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+
+    it('should remove the item from the Firebase db when given the reference', (done:any) => {
+      var childAddedSpy = jasmine.createSpy('childAdded');
+
+      ref.on('child_added', childAddedSpy);
+
+      O.remove(child)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childAddedSpy.calls.argsFor(0)[0].val()).toEqual(orphan);
+          expect(data.val()).toBeNull();
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+
+    it('should remove the item from the Firebase db when given the snapshot', (done:any) => {
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.remove(data)
+          .then(() => (<any>ref).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toBeNull();
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });
+
+
+    it('should remove the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.remove(unwrapMapFn(data))
+          .then(() => (<any>ref).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toBeNull();
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });
+    
+    it('should remove the whole list if no item is added', () => {
+      O.remove()
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(data.val()).toBe(null);
+        });
+    });
+
+
+    it('should throw an exception if input is not supported', () => {
+      var input = (<any>{lol:true});
+      expect(() => O.remove(input)).toThrowError(`FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: ${typeof input}`);
+    })
+  });
+  
+  describe('update', () => {
+    var orphan = { orphan: true };
+    var child:Firebase;
+
+    beforeEach(() => {
+      child = ref.push(orphan);
+    });    
+    
+    it('should update the item from the Firebase db when given the key', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child.key(), orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+    
+    it('should update the item from the Firebase db when given the reference', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child.ref(), orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });            
+
+    it('should update the item from the Firebase db when given the snapshot', (done:any) => {
+      var childChangedSpy = jasmine.createSpy('childChanged');
+      const orphanChange = { changed: true }
+      ref.on('child_changed', childChangedSpy);
+      O.update(child, orphanChange)
+        .then(() => (<any>ref).once('value'))
+        .then((data:FirebaseDataSnapshot) => {
+          expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({ 
+            orphan: true,
+            changed: true
+          });
+          
+          ref.off();
+        })
+        .then(done, done.fail);
+    });
+
+    it('should update the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
+      const orphanChange = { changed: true }
+      ref.on('child_added', (data:FirebaseDataSnapshot) => {
+        expect(data.val()).toEqual(orphan);
+        O.update(unwrapMapFn(data), orphanChange)
+          .then(() => (<any>child).once('value'))
+          .then((data:FirebaseDataSnapshot) => {
+            expect(data.val()).toEqual({ 
+              orphan: true,
+              changed: true
+            });
+            ref.off();
+          })
+          .then(done, done.fail);
+      });
+    });        
+  
+  });
+  
+});
+
+function noop() {}

--- a/angularfire2/utils/firebase_list_observable.ts
+++ b/angularfire2/utils/firebase_list_observable.ts
@@ -1,0 +1,81 @@
+import {Observable} from 'rxjs/Observable';
+import {Operator} from 'rxjs/Operator';
+import {Subscriber} from 'rxjs/Subscriber';
+import {Subscription} from 'rxjs/Subscription';
+import * as utils from './utils';
+
+export type FirebaseOperation = string | Firebase | FirebaseDataSnapshot | AFUnwrappedDataSnapshot
+
+export interface FirebaseOperationCases {
+  stringCase: () => Promise<void>;
+  firebaseCase?: () => Promise<void>;
+  snapshotCase?: () => Promise<void>;
+  unwrappedSnapshotCase?: () => Promise<void>;
+}
+
+export class FirebaseListObservable<T> extends Observable<T> {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, private _ref?:Firebase) {
+    super(subscribe);
+  }
+  lift<T, R>(operator: Operator<T, R>): Observable<R> {
+    const observable = new FirebaseListObservable<R>();
+    observable.source = this;
+    observable.operator = operator;
+    observable._ref = this._ref;
+    return observable;
+  }
+
+  push(val:any):FirebaseWithPromise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.push(val);
+  }
+  
+  update(item: FirebaseOperation, value: Object): Promise<void> {
+    return this._checkOperationCases(item, {
+      stringCase: () => this._ref.child(<string>item).update(value),
+      firebaseCase: () => (<Firebase>item).update(value),
+      snapshotCase: () => (<FirebaseDataSnapshot>item).ref().update(value),
+      unwrappedSnapshotCase: () => this._ref.child((<AFUnwrappedDataSnapshot>item).$key).update(value)
+    });
+  }
+
+  remove(item:FirebaseOperation = null): Promise<void> {
+    // TODO: remove override when typings are updated to include
+    // remove() returning a promise.
+    
+    // if no item parameter is provided, remove the whole list
+    if (!item) {
+      return this._ref.remove();
+    }
+    return this._checkOperationCases(item, {
+      stringCase: () => this._ref.child(<string>item).remove(),
+      firebaseCase: () => (<Firebase>item).remove(),
+      snapshotCase: () => (<FirebaseDataSnapshot>item).ref().remove(),
+      unwrappedSnapshotCase: () => this._ref.child((<AFUnwrappedDataSnapshot>item).$key).remove()
+    });
+  }
+  
+  _checkOperationCases(item: FirebaseOperation, cases: FirebaseOperationCases) : Promise<void> {
+    if (utils.isString(item)) {
+      return cases.stringCase();
+    } else if (utils.isFirebaseRef(item)) {
+      // Firebase ref
+      return cases.firebaseCase();
+    } else if (utils.isFirebaseDataSnapshot(item)) {
+      // Snapshot
+      return cases.snapshotCase();
+    } else if (utils.isAFUnwrappedSnapshot(item)) {
+      // Unwrapped snapshot
+      return cases.unwrappedSnapshotCase()
+    }
+    throw new Error(`FirebaseListObservable.remove requires a key, snapshot, reference, or unwrapped snapshot. Got: ${typeof item}`);
+  }
+  
+}
+
+export interface AFUnwrappedDataSnapshot {
+  $key: string;
+  $value?: string | number | boolean;
+}

--- a/angularfire2/utils/firebase_object_factory.js
+++ b/angularfire2/utils/firebase_object_factory.js
@@ -1,0 +1,32 @@
+System.register(['./firebase_object_observable', 'firebase', './utils'], function(exports_1) {
+    var firebase_object_observable_1, Firebase, utils;
+    function FirebaseObjectFactory(absoluteUrlOrDbRef, _a) {
+        var preserveSnapshot = (_a === void 0 ? {} : _a).preserveSnapshot;
+        var ref;
+        utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
+            isUrl: function () { return ref = new Firebase(absoluteUrlOrDbRef); },
+            isRef: function () { return ref = absoluteUrlOrDbRef; }
+        });
+        return new firebase_object_observable_1.FirebaseObjectObservable(function (obs) {
+            ref.on('value', function (snapshot) {
+                obs.next(preserveSnapshot ? snapshot : snapshot.val());
+            });
+            return function () { return ref.off(); };
+        }, ref);
+    }
+    exports_1("FirebaseObjectFactory", FirebaseObjectFactory);
+    return {
+        setters:[
+            function (firebase_object_observable_1_1) {
+                firebase_object_observable_1 = firebase_object_observable_1_1;
+            },
+            function (Firebase_1) {
+                Firebase = Firebase_1;
+            },
+            function (utils_1) {
+                utils = utils_1;
+            }],
+        execute: function() {
+        }
+    }
+});

--- a/angularfire2/utils/firebase_object_factory.spec.ts
+++ b/angularfire2/utils/firebase_object_factory.spec.ts
@@ -1,0 +1,91 @@
+import {FirebaseObjectFactory} from '../utils/firebase_object_factory';
+import {FirebaseObjectObservable} from '../utils/firebase_object_observable';
+import {beforeEach, it, describe, expect} from 'angular2/testing';
+import {Subscription} from 'rxjs';
+
+const rootFirebase = 'https://angularfire2-object-factory.firebaseio-demo.com';
+
+describe('FirebaseObjectFactory', () => {
+  var i = 0;
+  var ref: Firebase;
+  var observable: FirebaseObjectObservable<any>;
+  var subscription: Subscription;
+  var nextSpy: jasmine.Spy;
+
+  describe('constructor', () => {
+
+    it('should accept a Firebase db url in the constructor', () => {
+      const object = FirebaseObjectFactory(`${rootFirebase}/questions`);
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
+
+    it('should accept a Firebase db ref in the constructor', () => {
+      const object = FirebaseObjectFactory(new Firebase(`${rootFirebase}/questions`));
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
+    
+    it('should accept a Firebase db query in the constructor', () => {
+      const object = FirebaseObjectFactory(new Firebase(`${rootFirebase}/questions`).orderByChild('unwrapped'));
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
+
+  });
+
+  describe('methods', () => {
+
+    beforeEach((done: any) => {
+      i = Date.now();
+      ref = new Firebase(`${rootFirebase}/questions/${i}`);
+      nextSpy = nextSpy = jasmine.createSpy('next');
+      observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`);
+      ref.remove(done);
+    });
+
+    afterEach(() => {
+      if (subscription && !subscription.isUnsubscribed) {
+        subscription.unsubscribe();
+      }
+    })
+
+
+    it('should emit a null value if no value is present when subscribed', (done: any) => {
+      subscription = observable.subscribe(val => {
+        expect(val).toBe(null);
+        done();
+      });
+    });
+
+
+    it('should emit unwrapped data by default', (done: any) => {
+      ref.set({ unwrapped: 'bar' }, () => {
+        subscription = observable.subscribe(val => {
+          if (!val) return
+          expect(val).toEqual({ unwrapped: 'bar' });
+          done();
+        });
+      });
+    });
+
+
+    it('should emit snapshots if preserveSnapshot option is true', (done: any) => {
+      observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`, { preserveSnapshot: true });
+      ref.remove(() => {
+        ref.set('preserved snapshot!', () => {
+          subscription = observable.subscribe(data => {
+            expect(data.val()).toEqual('preserved snapshot!');
+            done();
+          });
+        });
+      })
+    });
+
+
+    it('should call off on all events when disposed', () => {
+      var firebaseSpy = spyOn(Firebase.prototype, 'off');
+      subscription = FirebaseObjectFactory(rootFirebase).subscribe();
+      expect(firebaseSpy).not.toHaveBeenCalled();
+      subscription.unsubscribe();
+      expect(firebaseSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/angularfire2/utils/firebase_object_factory.ts
+++ b/angularfire2/utils/firebase_object_factory.ts
@@ -1,0 +1,24 @@
+import {FirebaseObjectObservable} from './firebase_object_observable';
+import {Observer} from 'rxjs/Observer';
+import * as Firebase from 'firebase';
+import * as utils from './utils';
+
+export function FirebaseObjectFactory (absoluteUrlOrDbRef:string | Firebase | FirebaseQuery, {preserveSnapshot}:FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
+  let ref: Firebase;
+  utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
+    isUrl: () => ref = new Firebase(<string>absoluteUrlOrDbRef),
+    isRef: () => ref = <Firebase>absoluteUrlOrDbRef
+  });
+  
+  return new FirebaseObjectObservable((obs:Observer<any[]>) => {
+    ref.on('value', (snapshot) => {
+      obs.next(preserveSnapshot ? snapshot : snapshot.val())
+    });
+
+    return () => ref.off();
+  }, ref);
+}
+
+export interface FirebaseObjectFactoryOpts {
+  preserveSnapshot?: boolean;
+}

--- a/angularfire2/utils/firebase_object_observable.js
+++ b/angularfire2/utils/firebase_object_observable.js
@@ -1,0 +1,51 @@
+System.register(['rxjs/Observable'], function(exports_1) {
+    var __extends = (this && this.__extends) || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+    var Observable_1;
+    var FirebaseObjectObservable;
+    return {
+        setters:[
+            function (Observable_1_1) {
+                Observable_1 = Observable_1_1;
+            }],
+        execute: function() {
+            FirebaseObjectObservable = (function (_super) {
+                __extends(FirebaseObjectObservable, _super);
+                function FirebaseObjectObservable(subscribe, _ref) {
+                    _super.call(this, subscribe);
+                    this._ref = _ref;
+                }
+                FirebaseObjectObservable.prototype.lift = function (operator) {
+                    var observable = new FirebaseObjectObservable();
+                    observable.source = this;
+                    observable.operator = operator;
+                    observable._ref = this._ref;
+                    return observable;
+                };
+                FirebaseObjectObservable.prototype.set = function (value) {
+                    if (!this._ref) {
+                        throw new Error('No ref specified for this Observable!');
+                    }
+                    return this._ref.set(value);
+                };
+                FirebaseObjectObservable.prototype.update = function (value) {
+                    if (!this._ref) {
+                        throw new Error('No ref specified for this Observable!');
+                    }
+                    return this._ref.update(value);
+                };
+                FirebaseObjectObservable.prototype.remove = function () {
+                    if (!this._ref) {
+                        throw new Error('No ref specified for this Observable!');
+                    }
+                    return this._ref.remove();
+                };
+                return FirebaseObjectObservable;
+            })(Observable_1.Observable);
+            exports_1("FirebaseObjectObservable", FirebaseObjectObservable);
+        }
+    }
+});

--- a/angularfire2/utils/firebase_object_observable.spec.ts
+++ b/angularfire2/utils/firebase_object_observable.spec.ts
@@ -1,0 +1,116 @@
+import {describe,it,beforeEach} from 'angular2/testing';
+import {FirebaseObjectObservable} from './firebase_object_observable';
+import {Observer} from 'rxjs/Observer';
+import 'rxjs/add/operator/map';
+import * as Firebase from 'firebase';
+
+const rootUrl = 'https://angularfire2-obj-obs.firebaseio-demo.com/';
+
+describe('FirebaseObjectObservable', () => {
+  
+  var O:FirebaseObjectObservable<any>;
+  var ref:Firebase;
+
+  beforeEach(() => {
+    ref = new Firebase(rootUrl);
+    O = new FirebaseObjectObservable((observer:Observer<any>) => {
+    }, ref);
+  });
+
+  afterEach((done:any) => {
+    ref.off();
+    ref.remove();
+    done();
+  });
+  
+  it('should return an instance of FirebaseObservable when calling operators', () => {
+    var O:FirebaseObjectObservable<number> = new FirebaseObjectObservable((observer:Observer<number>) => {
+    });
+    expect(O.map(noop) instanceof FirebaseObjectObservable).toBe(true);
+  });
+  
+  describe('set', () => {
+    
+    it('should call set on the underlying ref', (done:any) => {
+      var setSpy = spyOn(ref, 'set');
+
+      O.subscribe();
+      O.set(1);
+      expect(setSpy).toHaveBeenCalledWith(1);
+      done();
+    });    
+    
+    it('should throw an exception if set when not subscribed', () => {
+      O = new FirebaseObjectObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.set('foo');
+      }).toThrowError('No ref specified for this Observable!')
+    });
+    
+    it('should accept any type of value without compilation error', () => {
+      O.set('foo');
+    });
+
+
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.set('foo').then(done, done.fail);
+    });        
+    
+  });
+  
+  describe('update', () => {
+    const updateObject = { hot: 'firebae' };
+    it('should call update on the underlying ref', () => {
+      var updateSpy = spyOn(ref, 'update');
+
+      O.subscribe();
+      O.update(updateObject);
+      expect(updateSpy).toHaveBeenCalledWith(updateObject);
+    });    
+    
+    it('should throw an exception if updated when not subscribed', () => {
+      O = new FirebaseObjectObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.update(updateObject);
+      }).toThrowError('No ref specified for this Observable!')
+    });
+    
+    it('should accept any type of value without compilation error', () => {
+      O.update(updateObject);
+    });
+
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.update(updateObject).then(done, done.fail);
+    });        
+    
+  });  
+
+  describe('remove', () => {
+
+    it('should call remove on the underlying ref', () => {
+      var removeSpy = spyOn(ref, 'remove');
+
+      O.subscribe();
+      O.remove();
+      expect(removeSpy).toHaveBeenCalledWith();
+    });    
+    
+    it('should throw an exception if removed when not subscribed', () => {
+      O = new FirebaseObjectObservable((observer:Observer<any>) => {});
+
+      expect(() => {
+        O.remove();
+      }).toThrowError('No ref specified for this Observable!')
+    });
+    
+    it('should resolve returned thenable when successful', (done:any) => {
+      O.remove().then(done, done.fail);
+    });        
+    
+  }); 
+  
+});
+
+function noop() {}

--- a/angularfire2/utils/firebase_object_observable.ts
+++ b/angularfire2/utils/firebase_object_observable.ts
@@ -1,0 +1,35 @@
+import {Observable} from 'rxjs/Observable';
+import {Operator} from 'rxjs/Operator';
+import {Subscriber} from 'rxjs/Subscriber';
+import {Subscription} from 'rxjs/Subscription';
+
+export class FirebaseObjectObservable<T> extends Observable<T> {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, private _ref?:Firebase) {
+    super(subscribe);
+  }
+  lift<T, R>(operator: Operator<T, R>): Observable<R> {
+    const observable = new FirebaseObjectObservable<R>();
+    observable.source = this;
+    observable.operator = operator;
+    observable._ref = this._ref;
+    return observable;
+  }
+  set(value: any): Promise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.set(value);
+  }
+  update(value: Object): Promise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.update(value);
+  }
+  remove(): Promise<void> {
+    if(!this._ref) {
+      throw new Error('No ref specified for this Observable!');
+    }
+    return this._ref.remove();
+  }
+}

--- a/angularfire2/utils/utils.js
+++ b/angularfire2/utils/utils.js
@@ -1,0 +1,44 @@
+System.register([], function(exports_1) {
+    function isPresent(obj) {
+        return obj !== undefined && obj !== null;
+    }
+    exports_1("isPresent", isPresent);
+    function isString(value) {
+        return typeof value === 'string';
+    }
+    exports_1("isString", isString);
+    function isFirebaseRef(value) {
+        return value instanceof Firebase;
+    }
+    exports_1("isFirebaseRef", isFirebaseRef);
+    function isFirebaseQuery(value) {
+        return typeof value.orderByChild === 'function';
+    }
+    exports_1("isFirebaseQuery", isFirebaseQuery);
+    function isFirebaseDataSnapshot(value) {
+        return typeof value.key === 'function';
+    }
+    exports_1("isFirebaseDataSnapshot", isFirebaseDataSnapshot);
+    function isAFUnwrappedSnapshot(value) {
+        return typeof value.$key === 'string';
+    }
+    exports_1("isAFUnwrappedSnapshot", isAFUnwrappedSnapshot);
+    function checkForUrlOrFirebaseRef(urlOrRef, cases) {
+        if (isString(urlOrRef)) {
+            return cases.isUrl();
+        }
+        if (isFirebaseRef(urlOrRef)) {
+            return cases.isRef();
+        }
+        if (isFirebaseQuery(urlOrRef)) {
+            return cases.isRef();
+        }
+        throw new Error('Provide a url or a Firebase database reference');
+    }
+    exports_1("checkForUrlOrFirebaseRef", checkForUrlOrFirebaseRef);
+    return {
+        setters:[],
+        execute: function() {
+        }
+    }
+});

--- a/angularfire2/utils/utils.ts
+++ b/angularfire2/utils/utils.ts
@@ -1,0 +1,41 @@
+export function isPresent(obj: any): boolean {
+  return obj !== undefined && obj !== null;
+}
+
+export function isString(value: any): boolean {
+  return typeof value === 'string';
+}
+
+export function isFirebaseRef(value: any): boolean {  
+  return value instanceof Firebase;
+}
+
+export function isFirebaseQuery(value: any): boolean {
+  return typeof value.orderByChild === 'function';
+}
+
+export function isFirebaseDataSnapshot(value: any): boolean {
+  return typeof value.key === 'function';
+}
+
+export function isAFUnwrappedSnapshot(value: any): boolean {
+  return typeof value.$key === 'string';
+}
+
+export interface CheckUrlRef {
+  isUrl: () => any;
+  isRef: () => any;
+}
+
+export function checkForUrlOrFirebaseRef(urlOrRef: string | Firebase | FirebaseQuery, cases: CheckUrlRef): any {
+  if (isString(urlOrRef)) {
+    return cases.isUrl();
+  }
+  if (isFirebaseRef(urlOrRef)) {
+    return cases.isRef();
+  }
+  if (isFirebaseQuery(urlOrRef)) {
+    return cases.isRef();
+  }
+  throw new Error('Provide a url or a Firebase database reference');  
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularfire2",
-  "version": "2.0.0-alpha.14",
+  "version": "2.0.0-alpha.15",
   "description": "",
   "main": "./dist/angularfire2.js",
   "scripts": {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -9,7 +9,7 @@ import * as utils from '../utils/utils'
 @Injectable()
 export class FirebaseDatabase {
   constructor(@Inject(FirebaseUrl) private fbUrl:string) {}
-  list (urlOrRef:string | Firebase, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
+  list (urlOrRef:string | Firebase | FirebaseQuery, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
     return utils.checkForUrlOrFirebaseRef(urlOrRef, {
       isUrl: () => FirebaseListFactory(getAbsUrl(this.fbUrl, <string>urlOrRef), opts),
       isRef: () => FirebaseListFactory(<Firebase>urlOrRef)

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -15,7 +15,7 @@ export class FirebaseDatabase {
       isRef: () => FirebaseListFactory(<Firebase>urlOrRef)
     });
   }
-  object(urlOrRef: string | Firebase, opts?:FirebaseObjectFactoryOpts):FirebaseObjectObservable<any> {
+  object(urlOrRef: string | Firebase | FirebaseQuery, opts?:FirebaseObjectFactoryOpts):FirebaseObjectObservable<any> {
     return utils.checkForUrlOrFirebaseRef(urlOrRef, {
       isUrl: () => FirebaseObjectFactory(getAbsUrl(this.fbUrl, <string>urlOrRef), opts),
       isRef: () => FirebaseObjectFactory(urlOrRef)

--- a/src/utils/firebase_object_factory.spec.ts
+++ b/src/utils/firebase_object_factory.spec.ts
@@ -23,6 +23,11 @@ describe('FirebaseObjectFactory', () => {
       const object = FirebaseObjectFactory(new Firebase(`${rootFirebase}/questions`));
       expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
     });
+    
+    it('should accept a Firebase db query in the constructor', () => {
+      const object = FirebaseObjectFactory(new Firebase(`${rootFirebase}/questions`).orderByChild('unwrapped'));
+      expect(object).toBeAnInstanceOf(FirebaseObjectObservable);
+    });
 
   });
 

--- a/src/utils/firebase_object_factory.ts
+++ b/src/utils/firebase_object_factory.ts
@@ -3,7 +3,7 @@ import {Observer} from 'rxjs/Observer';
 import * as Firebase from 'firebase';
 import * as utils from './utils';
 
-export function FirebaseObjectFactory (absoluteUrlOrDbRef:string | Firebase, {preserveSnapshot}:FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
+export function FirebaseObjectFactory (absoluteUrlOrDbRef:string | Firebase | FirebaseQuery, {preserveSnapshot}:FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
   let ref: Firebase;
   utils.checkForUrlOrFirebaseRef(absoluteUrlOrDbRef, {
     isUrl: () => ref = new Firebase(<string>absoluteUrlOrDbRef),

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -23,7 +23,7 @@ export interface CheckUrlRef {
   isRef: () => any;
 }
 
-export function checkForUrlOrFirebaseRef(urlOrRef: string | Firebase, cases: CheckUrlRef): any {
+export function checkForUrlOrFirebaseRef(urlOrRef: string | Firebase | FirebaseQuery, cases: CheckUrlRef): any {
   if (isString(urlOrRef)) {
     return cases.isUrl();
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,10 +7,11 @@ export function isString(value: any): boolean {
 }
 
 export function isFirebaseRef(value: any): boolean {  
-  if (value.ref && typeof value.ref === 'function' && value.ref() instanceof Firebase) {
-   return true;
-  }  
   return value instanceof Firebase;
+}
+
+export function isFirebaseQuery(value: any): boolean {
+  return typeof value.orderByChild === 'function';
 }
 
 export function isFirebaseDataSnapshot(value: any): boolean {
@@ -31,6 +32,9 @@ export function checkForUrlOrFirebaseRef(urlOrRef: string | Firebase | FirebaseQ
     return cases.isUrl();
   }
   if (isFirebaseRef(urlOrRef)) {
+    return cases.isRef();
+  }
+  if (isFirebaseQuery(urlOrRef)) {
     return cases.isRef();
   }
   throw new Error('Provide a url or a Firebase database reference');  

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,7 +6,10 @@ export function isString(value: any): boolean {
   return typeof value === 'string';
 }
 
-export function isFirebaseRef(value: any): boolean {
+export function isFirebaseRef(value: any): boolean {  
+  if (value.ref && typeof value.ref === 'function' && value.ref() instanceof Firebase) {
+   return true;
+  }  
   return value instanceof Firebase;
 }
 


### PR DESCRIPTION
This is just a small tweak to allow database.list to accept a firebase query as an arg.
This might help toward issue #16.

This allows me to do things like this:

`return this.af.database.list(this.ref.child("navigation").orderByChild("order")) as Observable<MenuItem[]>;`