### PR TITLE
chore(build): publish es6 assets to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "version": "2.0.0-alpha.15",
   "description": "",
   "main": "./dist/angularfire2.js",
+  "jsnext:main": "./dist/es6/angularfire2.js",
   "scripts": {
     "test": "npm run build; karma start",
     "docs": "typedoc --out docs/api/ --module commonjs --mode modules --name AngularFire2 src",
-    "build": "rm -rf dist; tsc && cp package.json README.md LICENSE .npmignore dist/",
-    "postbuild": "node tools/rewrite-published-package.js",
+    "build": "rm -rf dist; tsc",
+    "build_npm": "rm -rf dist && tsc -p tsconfig.publish.es5.json && tsc -p tsconfig.publish.es6.json",
+    "postbuild_npm": "cp package.json README.md .npmignore dist/ && npm run rewrite_npm_package",
+    "rewrite_npm_package": "node --harmony_destructuring tools/rewrite-published-package.js",
     "build_bundle": "cp -r src angularfire2 && tsc typings/main.d.ts angularfire2.ts --rootDir . --module system -t es5 --outFile dist/bundles/angularfire2.js  --moduleResolution node --emitDecoratorMetadata --experimentalDecorators"
   },
   "keywords": [
@@ -54,7 +57,7 @@
     "traceur": "0.0.96",
     "tsd": "^0.6.5",
     "typedoc": "github:jeffbcross/typedoc",
-    "typescript": "1.7.5",
+    "typescript": "1.8.9",
     "typings": "^0.6.2",
     "zone.js": "^0.6.6"
   },

--- a/publish.sh
+++ b/publish.sh
@@ -1,2 +1,2 @@
-npm run build
+npm run build_npm
 npm publish dist

--- a/tools/rewrite-published-package.js
+++ b/tools/rewrite-published-package.js
@@ -5,11 +5,13 @@
  */
 var fs = require('fs');
 var srcPackage = require('../package.json');
+var [MAIN, JSNEXT_MAIN] = ['main', 'jsnext:main'].map(k => srcPackage[k].replace('/dist/', '/'));
 var outPackage = Object.assign({}, srcPackage, {
   peerDependencies: srcPackage.dependencies,
-  main: "angularfire2.js",
-  typings: "angularfire2.d.ts"
+  main: MAIN,
+  typings: "angularfire2.d.ts",
+  "jsnext:main": JSNEXT_MAIN,
+  dependencies: undefined
 });
-delete outPackage.dependencies;
 
 fs.writeFileSync('./dist/package.json', JSON.stringify(outPackage, null, 2));

--- a/tsconfig.publish.es5.json
+++ b/tsconfig.publish.es5.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "commonjs",
+    "target": "es5",
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": true,
+    "removeComments": true
+  },
+  "files": [
+    "src/angularfire2.ts",
+    "src/angularfire2_worker_app.ts",
+    "src/angularfire2_worker_render.ts",
+    "src/utils/absolute_path_resolver.ts",
+    "src/utils/firebase_object_factory.ts",
+    "typings/main.d.ts"
+  ]
+}

--- a/tsconfig.publish.es6.json
+++ b/tsconfig.publish.es6.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "target": "es6",
+    "noImplicitAny": true,
+    "outDir": "dist/es6",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": true,
+    "removeComments": true,
+    "moduleResolution": "node"
+  },
+  "files": [
+    "src/angularfire2.ts",
+    "src/angularfire2_worker_app.ts",
+    "src/angularfire2_worker_render.ts",
+    "src/utils/absolute_path_resolver.ts",
+    "src/utils/firebase_object_factory.ts",
+    "typings/main/ambient/firebase/firebase.d.ts",
+    "typings/main/ambient/jasmine/jasmine.d.ts"
+  ]
+}


### PR DESCRIPTION
This includes an addition folder, es6, with an ES6 version of the library.
This is particularly useful for tools like rollup.