### PR TITLE
fix(FirebaseListFactory): prevent first item being duplicated when it…

### DIFF
--- a/src/utils/firebase_list_factory.spec.ts
+++ b/src/utils/firebase_list_factory.spec.ts
@@ -169,6 +169,11 @@ describe('FirebaseListFactory', () => {
         ).toEqual([val2, val1, val3]);
       });
 
+      it('should not duplicate the first item if it is the one that changed', () => {
+        expect(
+          onChildChanged([val1, val2, val3], val1, null)
+        ).not.toEqual([val1, val1, val2, val3]);
+      });
 
       it('should not mutate the input array', () => {
         var inputArr = [val1, val2];

--- a/src/utils/firebase_list_factory.ts
+++ b/src/utils/firebase_list_factory.ts
@@ -94,7 +94,9 @@ export function onChildChanged(arr:any[], child:any, prevKey:string): any[] {
   return arr.reduce((accumulator:any[], val:any, i:number) => {
     if (!prevKey && i==0) {
       accumulator.push(child);
-      accumulator.push(val);
+      if (val.key() !== child.key()) {
+        accumulator.push(val);
+      }
     } else if(val.key() === prevKey) {
       accumulator.push(val);
       accumulator.push(child);


### PR DESCRIPTION
Previously, the first list item would be duplicated if it was the one that changed. Now, we check that the first item in the existing array and the one that changed are different, and only _then_ do we push it to the accumulator.