### PR TITLE
Fix data binding expression in the example

### DIFF
--- a/docs/2-retrieving-data-as-objects.md
+++ b/docs/2-retrieving-data-as-objects.md
@@ -59,7 +59,7 @@ import {AngularFire, FirebaseObjectObservable} from 'angularfire2';
 @Component({
   selector: 'app',
   template: `
-  <h1>{{ item.name | async }}</h1>
+  <h1>{{ (item | async)?.name }}</h1>
   `,
 })
 export class AppComponent {


### PR DESCRIPTION
- "item.name" is not an observable so we can't use the async pipe on it.
- use the safe navigation operator to access the name property of the retrieved object.