### PR TITLE
Include source maps into angular-cli-build.js

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -53,8 +53,8 @@ module.exports = function(defaults) {
       '@angular/**/*.js',
       // above are the existing entries
       // below are the AngularFire entries
-      'angularfire2/**/*.js',
-      'firebase/lib/*.js'      
+      'angularfire2/**/*.+(js|js.map)',
+      'firebase/lib/*.+(js|js.map)'      
     ]
   });
 };
@@ -126,7 +126,7 @@ import { AngularFire, FirebaseListObservable } from 'angularfire2';
 })
 export class <MyApp>Component {
   constructor(af: AngularFire) {
-    
+
   }
 }
 


### PR DESCRIPTION
Withough srouce maps the angular-cli BundlePlugin for production fails
due to the source being referenced in the packaged js files