### PR TITLE
feat(FirebaseAuth): add resetPassword, changePassword and changeEmail

### DIFF
--- a/src/providers/auth.spec.ts
+++ b/src/providers/auth.spec.ts
@@ -2,7 +2,7 @@
 
 import {expect, describe, it, iit, beforeEach} from '@angular/core/testing';
 import {ReflectiveInjector, provide, Provider} from '@angular/core';
-import {Observable} from 'rxjs/Observable'
+import {Observable} from 'rxjs/Observable';
 import {
   FIREBASE_PROVIDERS,
   FirebaseRef,
@@ -31,11 +31,11 @@ describe('FirebaseAuth', () => {
     username: 'githubUsername',
     id: '12345',
     expires: 0
-  }
+  };
 
   const authObj = {
     token: 'key'
-  }
+  };
 
   const authState = {
     provider: 'github',
@@ -51,7 +51,7 @@ describe('FirebaseAuth', () => {
     github: providerMetadata,
     auth: authObj,
     expires: 0
-  }
+  };
 
   beforeEach(() => {
     authData = null;
@@ -68,7 +68,7 @@ describe('FirebaseAuth', () => {
 
   it('should be an observable', () => {
     expect(injector.get(FirebaseAuth)).toBeAnInstanceOf(Observable);
-  })
+  });
 
   describe('AuthState', () => {
 
@@ -82,6 +82,7 @@ describe('FirebaseAuth', () => {
       });
       backend = new FirebaseSdkAuthBackend(ref);
     });
+
     function updateAuthState(_authData: any): void {
       authData = _authData;
       if (authCb !== null) {
@@ -93,7 +94,7 @@ describe('FirebaseAuth', () => {
       updateAuthState(authState);
       let nextSpy = jasmine.createSpy('nextSpy');
       let auth = injector.get(FirebaseAuth);
-      
+
       auth.subscribe(nextSpy);
       expect(nextSpy).toHaveBeenCalledWith(AngularFireAuthState);
     });
@@ -122,386 +123,468 @@ describe('FirebaseAuth', () => {
     });
   });
 
-  function getArgIndex(callbackName: string): number {
-    //In the firebase API, the completion callback is the second argument for all but a few functions.
-    switch (callbackName) {
-      case 'authAnonymously':
-      case 'onAuth':
-        return 0;
-      case 'authWithOAuthToken':
-        return 2;
-      default:
-        return 1;
+
+  describe('when instantiated', function() {
+    let auth: FirebaseAuth = null;
+
+    beforeEach(() => {
+      ref = jasmine.createSpyObj('ref',
+        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
+          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
+          'unauth', 'getAuth', 'onAuth', 'offAuth',
+          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
+        ]);
+      backend = new FirebaseSdkAuthBackend(ref);
+    });
+
+    function getArgIndex(callbackName: string): number {
+      //In the firebase API, the completion callback is the second argument for all but a few functions.
+      switch (callbackName) {
+        case 'authAnonymously':
+        case 'onAuth':
+          return 0;
+        case 'authWithOAuthToken':
+          return 2;
+        default:
+          return 1;
+      }
     }
-  }
 
-  // calls the firebase callback
-  function callback(callbackName: string, callIndex?: number): Function {
-    callIndex = callIndex || 0; //assume the first call.
-    var argIndex = getArgIndex(callbackName);
-    return (<any>ref)[callbackName].calls.argsFor(callIndex)[argIndex];
-  }
+    // calls the firebase callback
+    function callback(callbackName: string, callIndex?: number): Function {
+      callIndex = callIndex || 0; //assume the first call.
+      var argIndex = getArgIndex(callbackName);
+      return (<any>ref)[callbackName].calls.argsFor(callIndex)[argIndex];
+    }
 
-  describe('firebaseAuthConfig', () => {
-    beforeEach(() => {
-      ref = jasmine.createSpyObj('ref',
-        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
-          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
-          'unauth', 'getAuth', 'onAuth', 'offAuth',
-          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
-        ]);
-      backend = new FirebaseSdkAuthBackend(ref);
-    });
+    describe('firebaseAuthConfig', () => {
 
-    it('should return a provider', () => {
-      expect(firebaseAuthConfig({ method: AuthMethods.Password })).toBeAnInstanceOf(Provider);
-    });
-
-    it('should use config in login', () => {
-      let config = {
-        method: AuthMethods.Anonymous
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login();
-      expect(ref.authAnonymously).toHaveBeenCalled();
-    });
-
-    it('should pass options on to login method', () => {
-      let config = {
-        method: AuthMethods.Anonymous,
-        remember: 'default'
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login();
-      expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
-    });
-
-    it('should be overridden by login\'s arguments', () => {
-      let config = {
-        method: AuthMethods.Anonymous
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login({
-        method: AuthMethods.Popup,
-        provider: AuthProviders.Google
-      });
-      expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('google', jasmine.any(Function), {});
-    });
-
-    it('should be merged with login\'s arguments', () => {
-      let config = {
-        method: AuthMethods.Popup,
-        provider: AuthProviders.Google,
-        scope: ['email']
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login({
-        provider: AuthProviders.Github
-      });
-      expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('github', jasmine.any(Function), {
-        scope: ['email']
-      });
-    });
-  });
-
-  describe('createUser', () => {
-    let auth: FirebaseAuth = null;
-    let credentials = { email: 'myname', password: 'password' };
-
-    beforeEach(() => {
-      ref = jasmine.createSpyObj('ref',
-        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
-          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
-          'unauth', 'getAuth', 'onAuth', 'offAuth',
-          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
-        ]);
-      backend = new FirebaseSdkAuthBackend(ref);
-      auth = new FirebaseAuth(backend);
-    });
-
-    it('should call createUser on a db reference', () => {
-      auth.createUser(credentials);
-      expect(ref.createUser)
-        .toHaveBeenCalledWith(credentials, jasmine.any(Function));
-    });
-
-  });
-
-  describe('login', () => {
-    let auth: FirebaseAuth = null;
-
-    beforeEach(() => {
-      ref = jasmine.createSpyObj('ref',
-        ['authWithCustomToken', 'authAnonymously', 'authWithPassword',
-          'authWithOAuthPopup', 'authWithOAuthRedirect', 'authWithOAuthToken',
-          'unauth', 'getAuth', 'onAuth', 'offAuth',
-          'createUser', 'changePassword', 'changeEmail', 'removeUser', 'resetPassword'
-        ]);
-      backend = new FirebaseSdkAuthBackend(ref);
-      auth = new FirebaseAuth(backend);
-    });
-
-    it('should reject if password is used without credentials', (done: any) => {
-      let config = {
-        method: AuthMethods.Password
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login().then(done.fail, done);
-    });
-
-    it('should reject if custom token is used without credentials', (done: any) => {
-      let config = {
-        method: AuthMethods.CustomToken
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login().then(done.fail, done);;
-    });
-
-    it('should reject if oauth token is used without credentials', (done: any) => {
-      let config = {
-        method: AuthMethods.OAuthToken
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login().then(done.fail, done);
-    });
-
-    it('should reject if popup is used without a provider', (done: any) => {
-      let config = {
-        method: AuthMethods.Popup
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login().then(done.fail, done);
-    });
-
-    it('should reject if redirect is used without a provider', (done: any) => {
-      let config = {
-        method: AuthMethods.Redirect
-      };
-      let auth = new FirebaseAuth(backend, config);
-      auth.login().then(done.fail, done);
-    });
-
-    describe('authWithCustomToken', () => {
-      let options = {
-        remember: 'default',
-        method: AuthMethods.CustomToken
-      };
-      let credentials = {
-        token: 'myToken'
-      };
-
-      it('passes custom token to underlying method', () => {
-        auth.login(credentials, options);
-        expect(ref.authWithCustomToken)
-          .toHaveBeenCalledWith('myToken', jasmine.any(Function), { remember: 'default' });
+      it('should return a provider', () => {
+        expect(firebaseAuthConfig({ method: AuthMethods.Password })).toBeAnInstanceOf(Provider);
       });
 
-      it('will reject the promise if authentication fails', (done: any) => {
-        auth.login(credentials, options).then(done.fail, done);
-        callback('authWithCustomToken')('myError');
+      it('should use config in login', () => {
+        let config = {
+          method: AuthMethods.Anonymous
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login();
+        expect(ref.authAnonymously).toHaveBeenCalled();
       });
 
-      it('will resolve the promise upon authentication', (done: any) => {
-        auth.login(credentials, options).then(result => {
-          expect(result).toEqual(AngularFireAuthState);
-          done();
-        }, done.fail);
-        callback('authWithCustomToken')(null, authState);
-      });
-    });
-
-    describe('authAnonymously', () => {
-      let options = {
-        remember: 'default',
-        method: AuthMethods.Anonymous
-      };
-      it('passes options object to underlying method', () => {
-        auth.login(options);
+      it('should pass options on to login method', () => {
+        let config = {
+          method: AuthMethods.Anonymous,
+          remember: 'default'
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login();
         expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
       });
 
-      it('will reject the promise if authentication fails', (done: any) => {
-        auth.login(options).then(done.fail, done);
-        callback('authAnonymously')('myError');
+      it('should be overridden by login\'s arguments', () => {
+        let config = {
+          method: AuthMethods.Anonymous
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login({
+          method: AuthMethods.Popup,
+          provider: AuthProviders.Google
+        });
+        expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('google', jasmine.any(Function), {});
       });
 
-      it('will resolve the promise upon authentication', (done: any) => {
-        auth.login(options).then(result => {
-          expect(result).toEqual(AngularFireAuthState);
-          done();
-        }, done.fail);
-        callback('authAnonymously')(null, authState);
+      it('should be merged with login\'s arguments', () => {
+        let config = {
+          method: AuthMethods.Popup,
+          provider: AuthProviders.Google,
+          scope: ['email']
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login({
+          provider: AuthProviders.Github
+        });
+        expect(ref.authWithOAuthPopup).toHaveBeenCalledWith('github', jasmine.any(Function), {
+          scope: ['email']
+        });
       });
     });
 
-    describe('authWithPassword', () => {
-      let options = { remember: 'default', method: AuthMethods.Password };
+    describe('createUser', () => {
       let credentials = { email: 'myname', password: 'password' };
 
-      it('should login with password credentials', () => {
+      beforeEach(() => {
+        auth = new FirebaseAuth(backend);
+      });
+
+      it('should call createUser on a db reference', () => {
+        auth.createUser(credentials);
+        expect(ref.createUser)
+          .toHaveBeenCalledWith(credentials, jasmine.any(Function));
+      });
+
+    });
+
+    describe('login', () => {
+
+      beforeEach(() => {
+        auth = new FirebaseAuth(backend);
+      });
+
+      it('should reject if password is used without credentials', (done: any) => {
         let config = {
-          method: AuthMethods.Password,
-          provider: AuthProviders.Password
+          method: AuthMethods.Password
         };
+        auth = new FirebaseAuth(backend, config);
+        auth.login().then(done.fail, done);
+      });
+
+      it('should reject if custom token is used without credentials', (done: any) => {
+        let config = {
+          method: AuthMethods.CustomToken
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login().then(done.fail, done);;
+      });
+
+      it('should reject if oauth token is used without credentials', (done: any) => {
+        let config = {
+          method: AuthMethods.OAuthToken
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login().then(done.fail, done);
+      });
+
+      it('should reject if popup is used without a provider', (done: any) => {
+        let config = {
+          method: AuthMethods.Popup
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login().then(done.fail, done);
+      });
+
+      it('should reject if redirect is used without a provider', (done: any) => {
+        let config = {
+          method: AuthMethods.Redirect
+        };
+        auth = new FirebaseAuth(backend, config);
+        auth.login().then(done.fail, done);
+      });
+
+      describe('authWithCustomToken', () => {
+        let options = {
+          remember: 'default',
+          method: AuthMethods.CustomToken
+        };
+        let credentials = {
+          token: 'myToken'
+        };
+
+        it('passes custom token to underlying method', () => {
+          auth.login(credentials, options);
+          expect(ref.authWithCustomToken)
+            .toHaveBeenCalledWith('myToken', jasmine.any(Function), { remember: 'default' });
+        });
+
+        it('will reject the promise if authentication fails', (done: any) => {
+          auth.login(credentials, options).then(done.fail, done);
+          callback('authWithCustomToken')('myError');
+        });
+
+        it('will resolve the promise upon authentication', (done: any) => {
+          auth.login(credentials, options).then(result => {
+            expect(result).toEqual(AngularFireAuthState);
+            done();
+          }, done.fail);
+          callback('authWithCustomToken')(null, authState);
+        });
+      });
+
+      describe('authAnonymously', () => {
+        let options = {
+          remember: 'default',
+          method: AuthMethods.Anonymous
+        };
+        it('passes options object to underlying method', () => {
+          auth.login(options);
+          expect(ref.authAnonymously).toHaveBeenCalledWith(jasmine.any(Function), { remember: 'default' });
+        });
+
+        it('will reject the promise if authentication fails', (done: any) => {
+          auth.login(options).then(done.fail, done);
+          callback('authAnonymously')('myError');
+        });
+
+        it('will resolve the promise upon authentication', (done: any) => {
+          auth.login(options).then(result => {
+            expect(result).toEqual(AngularFireAuthState);
+            done();
+          }, done.fail);
+          callback('authAnonymously')(null, authState);
+        });
+      });
+
+      describe('authWithPassword', () => {
+        let options = { remember: 'default', method: AuthMethods.Password };
+        let credentials = { email: 'myname', password: 'password' };
+
+        it('should login with password credentials', () => {
+          let config = {
+            method: AuthMethods.Password,
+            provider: AuthProviders.Password
+          };
+          const credentials = {
+            email: 'david@fire.com',
+            password: 'supersecretpassword'
+          };
+          auth = new FirebaseAuth(backend, config);
+          auth.login(credentials);
+          expect(ref.authWithPassword).toHaveBeenCalledWith(credentials,
+            jasmine.any(Function),
+            { provider: config.provider });
+        });
+
+        it('passes options and credentials object to underlying method', () => {
+          auth.login(credentials, options);
+          expect(ref.authWithPassword).toHaveBeenCalledWith(
+            credentials,
+            jasmine.any(Function),
+            { remember: options.remember }
+          );
+        });
+
+        it('will revoke the promise if authentication fails', (done: any) => {
+          auth.login(credentials, options).then(done.fail, done);
+          callback('authWithPassword')('myError');
+        });
+
+        it('will resolve the promise upon authentication', (done: any) => {
+          auth.login(credentials, options).then(result => {
+            expect(result).toEqual(AngularFireAuthState);
+            done();
+          }, done.fail);
+          callback('authWithPassword')(null, authState);
+        });
+      });
+
+      describe('authWithOAuthPopup', function() {
+        let options = {
+          method: AuthMethods.Popup,
+          provider: AuthProviders.Github
+        };
+        it('passes provider and options object to underlying method', () => {
+          let customOptions = Object.assign({}, options);
+          customOptions.scope = ['email'];
+          auth.login(customOptions);
+          expect(ref.authWithOAuthPopup).toHaveBeenCalledWith(
+            'github',
+            jasmine.any(Function),
+            { scope: ['email'] }
+          );
+        });
+
+        it('will reject the promise if authentication fails', (done: any) => {
+          auth.login(options).then(done.fail, done);
+          callback('authWithOAuthPopup')('myError');
+        });
+
+        it('will resolve the promise upon authentication', (done: any) => {
+          auth.login(options).then(result => {
+            expect(result).toEqual(AngularFireAuthState);
+            done();
+          }, done.fail);
+          callback('authWithOAuthPopup')(null, authState);
+        });
+      });
+
+      describe('authWithOAuthRedirect', () => {
+        const options = {
+          method: AuthMethods.Redirect,
+          provider: AuthProviders.Github
+        };
+        it('passes provider and options object to underlying method', () => {
+          let customOptions = Object.assign({}, options);
+          customOptions.scope = ['email'];
+          auth.login(customOptions);
+          expect(ref.authWithOAuthRedirect).toHaveBeenCalledWith(
+            'github',
+            jasmine.any(Function),
+            { scope: ['email'] }
+          );
+        });
+
+        it('will reject the promise if authentication fails', (done: any) => {
+          auth.login(options).then(done.fail, done);
+          callback('authWithOAuthRedirect')('myError');
+        });
+
+        it('will resolve the promise upon authentication', (done: any) => {
+          auth.login(options).then(result => {
+            expect(result).toEqual(AngularFireAuthState);
+            done();
+          }, done.fail);
+          callback('authWithOAuthRedirect')(null, authState);
+        });
+      });
+
+      describe('authWithOAuthToken', () => {
+        const options = {
+          method: AuthMethods.OAuthToken,
+          provider: AuthProviders.Github,
+          scope: ['email']
+        };
+        const token = 'GITHUB_TOKEN';
         const credentials = {
-          email: 'david@fire.com',
+          token: token
+        };
+        it('passes provider, token, and options object to underlying method', () => {
+          auth.login(credentials, options);
+          expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
+            'github',
+            token,
+            jasmine.any(Function),
+            { scope: ['email'] }
+          );
+        });
+
+        it('passes provider, OAuth credentials, and options object to underlying method', () => {
+          let customOptions = Object.assign({}, options);
+          customOptions.provider = AuthProviders.Twitter;
+          let twitterCredentials = {
+            "user_id": "<USER-ID>",
+            "oauth_token": "<ACCESS-TOKEN>",
+            "oauth_token_secret": "<ACCESS-TOKEN-SECRET>"
+          };
+          auth.login(twitterCredentials, customOptions);
+          expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
+            'twitter',
+            twitterCredentials,
+            jasmine.any(Function),
+            { scope: ['email'] }
+          );
+        });
+
+        it('will reject the promise if authentication fails', (done: any) => {
+          let creds = {
+            token: ''
+          };
+          auth.login(creds, options).then(done.fail, done);
+          callback('authWithOAuthToken')('myError');
+        });
+
+        it('will resolve the promise upon authentication', (done: any) => {
+          auth.login(credentials, options).then(result => {
+            expect(result).toEqual(AngularFireAuthState);
+            done();
+          }, done.fail);
+          callback('authWithOAuthToken')(null, authState);
+        });
+      });
+
+      describe('unauth()', () => {
+        it('will call unauth() on the backing ref if logged in', () => {
+          (<any>ref).getAuth.and.returnValue({ provider: 'twitter' });
+          auth.logout();
+          expect(ref.unauth).toHaveBeenCalled();
+        });
+
+        it('will NOT call unauth() on the backing ref if NOT logged in', () => {
+          (<any>ref).getAuth.and.returnValue(null);
+          auth.logout();
+          expect(ref.unauth).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('resetPassword', () => {
+      let credentials: FirebaseResetPasswordCredentials;
+
+      beforeEach(() => {
+        auth = new FirebaseAuth(backend);
+
+        credentials = {email: 'julien@fire.com'};
+      });
+
+      it('should pass credentials to underlying method', () => {
+        auth.resetPassword(credentials);
+        expect(ref.resetPassword).toHaveBeenCalledWith(credentials, jasmine.any(Function));
+      });
+
+      it('should reject the promise if the reset password fails', (done: any) => {
+        auth.resetPassword(credentials).then(done.fail, done);
+        callback('resetPassword')('myError');
+      });
+
+      it('should resolve the promise upon authentication', (done: any) => {
+        auth.resetPassword(credentials).then(result => {
+          expect(result).toBeUndefined();
+          done();
+        }, done.fail);
+        callback('resetPassword')();
+      });
+    });
+
+    describe('changePassword', () => {
+      let credentials: FirebaseChangePasswordCredentials;
+
+      beforeEach(() => {
+        auth = new FirebaseAuth(backend);
+
+        credentials = {
+          email: 'julien@fire.com',
+          oldPassword: 'supersecretpassword',
+          newPassword: 'bettersecretpassword'
+        };
+      });
+
+      it('should pass credentials to underlying method', () => {
+        auth.changePassword(credentials);
+        expect(ref.changePassword).toHaveBeenCalledWith(credentials, jasmine.any(Function));
+      });
+
+      it('should reject the promise if the change password fails', (done: any) => {
+        auth.changePassword(credentials).then(done.fail, done);
+        callback('changePassword')('myError');
+      });
+
+      it('should resolve the promise', (done: any) => {
+        auth.changePassword(credentials).then(result => {
+          expect(result).toBeUndefined();
+          done();
+        }, done.fail);
+        callback('changePassword')();
+      });
+    });
+
+    describe('changeEmail', () => {
+      let credentials: FirebaseChangeEmailCredentials;
+
+      beforeEach(() => {
+        auth = new FirebaseAuth(backend);
+
+        credentials = {
+          oldEmail: 'julien@fire.com',
+          newEmail: 'david@fire.com',
           password: 'supersecretpassword'
         };
-        let auth = new FirebaseAuth(backend, config);
-        auth.login(credentials);
-        expect(ref.authWithPassword).toHaveBeenCalledWith(credentials,
-          jasmine.any(Function),
-          { provider: config.provider });
       });
 
-      it('passes options and credentials object to underlying method', () => {
-        auth.login(credentials, options);
-        expect(ref.authWithPassword).toHaveBeenCalledWith(
-          credentials,
-          jasmine.any(Function),
-          { remember: options.remember }
-        );
+      it('should pass credentials to underlying method', () => {
+        auth.changeEmail(credentials);
+        expect(ref.changeEmail).toHaveBeenCalledWith(credentials, jasmine.any(Function));
       });
 
-      it('will revoke the promise if authentication fails', (done: any) => {
-        auth.login(credentials, options).then(done.fail, done);
-        callback('authWithPassword')('myError');
+      it('should reject the promise if the change email fails', (done: any) => {
+        auth.changeEmail(credentials).then(done.fail, done);
+        callback('changeEmail')('myError');
       });
 
-      it('will resolve the promise upon authentication', (done: any) => {
-        auth.login(credentials, options).then(result => {
-          expect(result).toEqual(AngularFireAuthState);
+      it('should resolve the promise', (done: any) => {
+        auth.changeEmail(credentials).then(result => {
+          expect(result).toBeUndefined();
           done();
         }, done.fail);
-        callback('authWithPassword')(null, authState);
-      });
-    });
-
-    describe('authWithOAuthPopup', function() {
-      let options = {
-        method: AuthMethods.Popup,
-        provider: AuthProviders.Github
-      };
-      it('passes provider and options object to underlying method', () => {
-        let customOptions = Object.assign({}, options);
-        customOptions.scope = ['email'];
-        auth.login(customOptions);
-        expect(ref.authWithOAuthPopup).toHaveBeenCalledWith(
-          'github',
-          jasmine.any(Function),
-          { scope: ['email'] }
-        );
-      });
-
-      it('will reject the promise if authentication fails', (done: any) => {
-        auth.login(options).then(done.fail, done);
-        callback('authWithOAuthPopup')('myError');
-      });
-
-      it('will resolve the promise upon authentication', (done: any) => {
-        auth.login(options).then(result => {
-          expect(result).toEqual(AngularFireAuthState);
-          done();
-        }, done.fail);
-        callback('authWithOAuthPopup')(null, authState);
-      });
-    });
-
-    describe('authWithOAuthRedirect', () => {
-      const options = {
-        method: AuthMethods.Redirect,
-        provider: AuthProviders.Github
-      };
-      it('passes provider and options object to underlying method', () => {
-        let customOptions = Object.assign({}, options);
-        customOptions.scope = ['email'];
-        auth.login(customOptions);
-        expect(ref.authWithOAuthRedirect).toHaveBeenCalledWith(
-          'github',
-          jasmine.any(Function),
-          { scope: ['email'] }
-        );
-      });
-
-      it('will reject the promise if authentication fails', (done: any) => {
-        auth.login(options).then(done.fail, done);
-        callback('authWithOAuthRedirect')('myError');
-      });
-
-      it('will resolve the promise upon authentication', (done: any) => {
-        auth.login(options).then(result => {
-          expect(result).toEqual(AngularFireAuthState);
-          done();
-        }, done.fail);
-        callback('authWithOAuthRedirect')(null, authState);
-      });
-    });
-
-    describe('authWithOAuthToken', () => {
-      const options = {
-        method: AuthMethods.OAuthToken,
-        provider: AuthProviders.Github,
-        scope: ['email']
-      };
-      const token = 'GITHUB_TOKEN';
-      const credentials = {
-        token: token
-      };
-      it('passes provider, token, and options object to underlying method', () => {
-        auth.login(credentials, options);
-        expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
-          'github',
-          token,
-          jasmine.any(Function),
-          { scope: ['email'] }
-        );
-      });
-
-      it('passes provider, OAuth credentials, and options object to underlying method', () => {
-        let customOptions = Object.assign({}, options);
-        customOptions.provider = AuthProviders.Twitter;
-        let twitterCredentials = {
-          "user_id": "<USER-ID>",
-          "oauth_token": "<ACCESS-TOKEN>",
-          "oauth_token_secret": "<ACCESS-TOKEN-SECRET>"
-        };
-        auth.login(twitterCredentials, customOptions);
-        expect(ref.authWithOAuthToken).toHaveBeenCalledWith(
-          'twitter',
-          twitterCredentials,
-          jasmine.any(Function),
-          { scope: ['email'] }
-        );
-      });
-
-      it('will reject the promise if authentication fails', (done: any) => {
-        let creds = {
-          token: ''
-        };
-        auth.login(creds, options).then(done.fail, done);
-        callback('authWithOAuthToken')('myError');
-      });
-
-      it('will resolve the promise upon authentication', (done: any) => {
-        auth.login(credentials, options).then(result => {
-          expect(result).toEqual(AngularFireAuthState);
-          done();
-        }, done.fail);
-        callback('authWithOAuthToken')(null, authState);
-      });
-    });
-
-
-    describe('unauth()', () => {
-      it('will call unauth() on the backing ref if logged in', () => {
-        (<any>ref).getAuth.and.returnValue({ provider: 'twitter' }); auth.logout();
-        expect(ref.unauth).toHaveBeenCalled();
-      });
-
-      it('will NOT call unauth() on the backing ref if NOT logged in', () => {
-        (<any>ref).getAuth.and.returnValue(null);
-        auth.logout();
-        expect(ref.unauth).not.toHaveBeenCalled();
+        callback('changeEmail')();
       });
     });
   });

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -104,6 +104,18 @@ export class FirebaseAuth extends ReplaySubject<FirebaseAuthState> {
     return this._authBackend.createUser(credentials);
   }
 
+  public resetPassword(credentials: FirebaseResetPasswordCredentials): Promise<void> {
+    return this._authBackend.resetPassword(credentials);
+  }
+
+  public changePassword(credentials: FirebaseChangePasswordCredentials): Promise<void> {
+    return this._authBackend.changePassword(credentials);
+  }
+
+  public changeEmail(credentials: FirebaseChangeEmailCredentials): Promise<void> {
+    return this._authBackend.changeEmail(credentials);
+  }
+
   /**
    * Merges the config object that is passed in with the configuration
    * provided through DI. Giving precendence to the one that was passed.

--- a/src/providers/auth_backend.ts
+++ b/src/providers/auth_backend.ts
@@ -10,6 +10,9 @@ export abstract class AuthBackend {
   abstract getAuth(): FirebaseAuthData;
   abstract unauth(): void;
   abstract createUser(credentials: FirebaseCredentials): Promise<FirebaseAuthData>;
+  abstract resetPassword(credentials: FirebaseResetPasswordCredentials): Promise<void>;
+  abstract changePassword(credentials: FirebaseChangePasswordCredentials): Promise<void>;
+  abstract changeEmail(credentials: FirebaseChangeEmailCredentials): Promise<void>;
 }
 
 // Firebase only provides typings for google

--- a/src/providers/firebase_sdk_auth_backend.ts
+++ b/src/providers/firebase_sdk_auth_backend.ts
@@ -45,7 +45,7 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
 
   authWithCustomToken(token: string, options?: any): Promise<FirebaseAuthState> {
     let p = new Promise((res, rej) => {
-      this._fbRef.authWithCustomToken(token, this._handleFirebaseCb(res, rej, options), options);
+      this._fbRef.authWithCustomToken(token, this._handleFirebaseAuthCb(res, rej, options), options);
     });
 
     return p;
@@ -53,7 +53,7 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
 
   authAnonymously(options?: any): Promise<FirebaseAuthState> {
     let p = new Promise((res, rej) => {
-      this._fbRef.authAnonymously(this._handleFirebaseCb(res, rej, options), options);
+      this._fbRef.authAnonymously(this._handleFirebaseAuthCb(res, rej, options), options);
     });
 
     return p;
@@ -62,7 +62,7 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
   authWithPassword(credentials: FirebaseCredentials, options?: any)
     : Promise<FirebaseAuthState> {
     let p = new Promise((res, rej) => {
-      this._fbRef.authWithPassword(credentials, this._handleFirebaseCb(res, rej, options), options);
+      this._fbRef.authWithPassword(credentials, this._handleFirebaseAuthCb(res, rej, options), options);
     });
 
     return p;
@@ -71,7 +71,7 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
   authWithOAuthPopup(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
     let p = new Promise((res, rej) => {
       this._fbRef.authWithOAuthPopup(this._providerToString(provider),
-        this._handleFirebaseCb(res, rej, options), options);
+        this._handleFirebaseAuthCb(res, rej, options), options);
     });
 
     return p;
@@ -85,7 +85,7 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
   authWithOAuthRedirect(provider: AuthProviders, options?: any): Promise<FirebaseAuthState> {
     let p = new Promise((res, rej) => {
       this._fbRef.authWithOAuthRedirect(this._providerToString(provider),
-        this._handleFirebaseCb(res, rej, options), options);
+        this._handleFirebaseAuthCb(res, rej, options), options);
     });
 
     return p;
@@ -98,13 +98,45 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
         ? (<OAuth2Credentials>credentialsObj).token
         : credentialsObj;
       this._fbRef.authWithOAuthToken(this._providerToString(provider), credentials,
-        this._handleFirebaseCb(res, rej, options), options);
+        this._handleFirebaseAuthCb(res, rej, options), options);
     });
 
     return p;
   }
 
-  private _handleFirebaseCb(res: Function, rej: Function, options: any): (err: any, auth?: FirebaseAuthData) => void {
+  resetPassword(credentials: FirebaseResetPasswordCredentials): Promise<void> {
+    const p = new Promise<void>((res, rej) => {
+      this._fbRef.resetPassword(credentials, this._handleFirebaseCb(res, rej));
+    });
+    return p;
+  }
+
+  changePassword(credentials: FirebaseChangePasswordCredentials): Promise<void> {
+    const p = new Promise<void>((res, rej) => {
+      this._fbRef.changePassword(credentials, this._handleFirebaseCb(res, rej));
+    });
+    return p;
+  }
+
+  changeEmail(credentials: FirebaseChangeEmailCredentials): Promise<void> {
+    const p = new Promise<void>((res, rej) => {
+      this._fbRef.changeEmail(credentials, this._handleFirebaseCb(res, rej));
+    });
+    return p;
+  }
+
+  private _handleFirebaseCb(res: Function, rej: Function): (err: any) => void {
+    return function (err) {
+      if (err) {
+        return rej(err);
+      } else {
+        const args = Array.prototype.slice.call(arguments, 1);
+        return res.apply(null, args);
+      }
+    };
+  }
+
+  private _handleFirebaseAuthCb(res: Function, rej: Function, options: any): (err: any, auth?: FirebaseAuthData) => void {
     return (err, auth?) => {
       if (err) {
         return rej(err);


### PR DESCRIPTION
Expose the methods `resetPassword`, `changePassword` and `changeEmail` of `Firebase` to `FirebaseAuth`.