### PR TITLE
docs: update npm vendor files

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -46,11 +46,11 @@ module.exports = function(defaults) {
     vendorNpmFiles: [
       'systemjs/dist/system-polyfills.js',
       'systemjs/dist/system.src.js',
-      'zone.js/dist/*.js',
+      'zone.js/dist/**/*.+(js|js.map)',
       'es6-shim/es6-shim.js',
-      'reflect-metadata/*.js',
-      'rxjs/**/*.js',
-      '@angular/**/*.js',
+      'reflect-metadata/**/*.+(js|js.map)',
+      'rxjs/**/*.+(js|js.map)',
+      '@angular/**/*.+(js|js.map)',
       // above are the existing entries
       // below are the AngularFire entries
       'angularfire2/**/*.js',


### PR DESCRIPTION
This will update the current paths to match the `angular-cli-build.js` file built by the latest Angular CLI.