### PR TITLE
change docs when installing typings global install

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -25,7 +25,7 @@ Now that you have a new project setup, install AngularFire 2 and Firebase from n
 
 ```bash
 npm install typings -g
-typings install --save --ambient firebase
+typings install --save -g firebase
 ```
 
 AngularFire 2 is written in Typescript and depends on typings for the Firebase SDK. To get a clean build, install typings and download the Firebase typings.


### PR DESCRIPTION
`typings install --save --ambient firebase` will results in 
`typings ERR! deprecated The "ambient" flag is deprecated. Please use "global" instead`
it is depreicated in version `1.0`
`typings install --save -g firebase` will fix it