### PR TITLE
firebase needs to be installed before angularfire2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Status: Beta
 ## Install
 
 ```bash
-npm install angularfire2 firebase --save
+npm install firebase angularfire2 --save
 ```
 
 ## Example use:


### PR DESCRIPTION
There was a dependency issue in the README.md where angularfire2 was trying to be installed before firebase.   