### PR TITLE
Consistent promise rejections

### DIFF
--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -147,7 +147,7 @@ export class AngularFireAuth extends ReplaySubject<FirebaseAuthState> {
 
   private _reject(msg: string): firebase.Promise<FirebaseAuthState> {
     return (<Promise<FirebaseAuthState>>new Promise((res, rej) => {
-      return rej(msg);
+      return rej(new Error(msg));
     }));
   }
 


### PR DESCRIPTION
The auth backend rejects promises with `Error` objects. angularfire should do the same if the promise is rejected before it reaches the backends.