### PR TITLE
fix(auth): check protocol before calling getRedirectResult

### DIFF
--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -9,7 +9,7 @@ import {
   FirebaseObjectFactory
 } from './utils/firebase_object_factory';
 import * as utils from './utils/utils';
-import {FirebaseConfig, FirebaseApp} from './tokens';
+import { FirebaseConfig, FirebaseApp, WindowLocation } from './tokens';
 import { FirebaseAppConfig } from './interfaces';
 import {
   AuthBackend,
@@ -55,7 +55,11 @@ export const FIREBASE_PROVIDERS:any[] = [
     provide: AuthBackend,
     useFactory: _getAuthBackend,
     deps: [FirebaseApp]
-  }
+  },
+  {
+    provide: WindowLocation,
+    useValue: window.location
+  },
 ];
 
 function _getAuthBackend(app: firebase.app.App): FirebaseSdkAuthBackend {
@@ -86,7 +90,8 @@ export {
   firebaseAuthConfig,
   FirebaseAuthState,
   AuthMethods,
-  AuthProviders
+  AuthProviders,
+  WindowLocation
 }
 
 export { FirebaseConfig, FirebaseApp, FirebaseAuthConfig, FirebaseRef, FirebaseUrl } from './tokens';

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -3,6 +3,7 @@ import {OpaqueToken} from '@angular/core';
 export const FirebaseConfig = new OpaqueToken('FirebaseUrl');
 export const FirebaseApp = new OpaqueToken('FirebaseApp')
 export const FirebaseAuthConfig = new OpaqueToken('FirebaseAuthConfig');
+export const WindowLocation = new OpaqueToken('WindowLocation');
 // TODO: Deprecate
 export const FirebaseRef = FirebaseApp;
 export const FirebaseUrl = FirebaseConfig;


### PR DESCRIPTION
When using AngularFire in non-browser environments, such as Ionic,
subscribing to the AngularFireAuth service would cause an error to
be thrown. This was because getRedirectResult() is always called
at the beginning of the auth observable, to determine if the page
is being loaded after a redirect-based oAuth flow. However, calling
this method is not supported if location.protocol is not http or https.
In the case of Ionic, the protocol is file:.
This change adds a check before calling getRedirectResult to make sure
the protocol is http or https.

BREAKING CHANGE:

The AngularFireAuth class has changed the order of its constructor arguments.
Since this is usually instantiated automatically via dependency injection,
it shouldn't affect common usage of the library. However, if manually
instantiating AngularFireAuth in tests or in an application, the order of
arguments is now: AuthBackend, WindowLocation, 

Fixes #243