### PR TITLE
fix(auth): Return provider data

### DIFF
--- a/src/providers/auth_backend.ts
+++ b/src/providers/auth_backend.ts
@@ -46,10 +46,10 @@ export interface FirebaseAuthState {
   provider: AuthProviders;
   auth: firebase.User;
   expires?: number;
-  github?: CommonOAuthCredential;
-  google?: GoogleCredential;
-  twitter?: TwitterCredential;
-  facebook?: CommonOAuthCredential;
+  github?: firebase.UserInfo;
+  google?: firebase.UserInfo;
+  twitter?: firebase.UserInfo;
+  facebook?: firebase.UserInfo;
   anonymous?: boolean;
 }
 
@@ -69,7 +69,8 @@ export interface TwitterCredential extends CommonOAuthCredential {
 
 export type OAuthCredential = CommonOAuthCredential | GoogleCredential | TwitterCredential;
 
-export function authDataToAuthState(authData: firebase.User, providerData?: OAuthCredential): FirebaseAuthState {
+export function authDataToAuthState(authData: firebase.User): FirebaseAuthState {
+  let providerData = authData.providerData[0];
   if (!authData) return null;
   let providerId;
   let { uid } = authData;
@@ -80,24 +81,24 @@ export function authDataToAuthState(authData: firebase.User, providerData?: OAut
     authState.anonymous = true;
     return authState;
   } else {
-    providerId = authData.providerData[0].providerId;
+    providerId = providerData.providerId;
   }
 
   switch (providerId) {
     case 'github.com':
-      authState.github = <CommonOAuthCredential>providerData;
+      authState.github = providerData;
       authState.provider = AuthProviders.Github;
       break;
     case 'twitter.com':
-      authState.twitter = <TwitterCredential>providerData;
+      authState.twitter = providerData;
       authState.provider = AuthProviders.Twitter;
       break;
     case 'facebook.com':
-      authState.facebook = <CommonOAuthCredential>providerData;
+      authState.facebook = providerData;
       authState.provider = AuthProviders.Facebook;
       break;
     case 'google.com':
-      authState.google = <GoogleCredential>providerData;
+      authState.google = providerData;
       authState.provider = AuthProviders.Google;
       break;
     case 'password':


### PR DESCRIPTION
@jeffbcross I could be totally wrong here since I'm still catching up on the new firebase changes.
But it seems like the current auth implementation doesn't return any provider data (at least for facebook it appears to return `facebook: undefined`). I think we actually want to return `firebase.UserInfo` for all of providers and get the data from the providerData.

Let me know if this looks right or if I'm missing something. If it looks good I'll update the tests accordingly.