### PR TITLE
Update typings installation instructions.

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -30,15 +30,11 @@ Now that you have a new project setup, install AngularFire 2 and Firebase from n
 
 ### 3. Include Firebase SDK typings
 
-In your `tsconfig.json` file include the following line in your `"files"` array:
-
-```json
-"files": [
-  "node_modules/angularfire2/firebase3.d.ts"
-]
+```bash
+typings install file:node_modules/angularfire2/firebase3.d.ts --save --global && typings install
 ```
 
-This is a temporary step until the Firebase typings are published to npm.
+This saves the typings reference into `typings.json` and installs it.
 
 ### 4. Include AngularFire 2 and Firebase in the vendor files
 

--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -36,6 +36,8 @@ typings install file:node_modules/angularfire2/firebase3.d.ts --save --global &&
 
 This saves the typings reference into `typings.json` and installs it.
 
+Note: for typings < 1, use the `--ambient` flag instead of `--global`.
+
 ### 4. Include AngularFire 2 and Firebase in the vendor files
 
 Open `angular-cli-build.js`.


### PR DESCRIPTION
This minor update instructs users to install the firebase3 typings file into `typings.json` instead of into `tsconfig.js`. I believe that this method is better because some projects use the `"excludes"` property in tsconfig (I encountered this in an Ionic v2 setup), which is mutually exclusive to the `"files"` property. 

> The "files" property cannot be used in conjunction with the "exclude" property <sup>[1](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)</sup> 

If users do not know this, they can inadvertently begin including files that they had been meaning to exclude. Otherwise they might think they have to refactor their globbing pattern to use with `"files"` instead of `"exclude"`, which isn't necessary if the typings are left out of tsconfig. 

I shared this solution on issue https://github.com/angular/angularfire2/issues/234#issuecomment-229560239 and it seems to have worked for other people as well.