### PR TITLE
Moved ngFor directive to <li> rather than <ul>

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -192,8 +192,8 @@ export class <MyApp>Component {
 Open `/src/app/<my-app>.component.html`:
 
 ```html
-<ul *ngFor="let item of items | async">
-  <li class="text">
+<ul>
+  <li class="text" *ngFor="let item of items | async">
     {{item.$value}}
   </li>
 </ul>


### PR DESCRIPTION
It was probably a typo to place ngFor directive in "ul" tag rather than "ul" tag.

Most documents I've read with this syntax (including here https://github.com/angular/angularfire2 ) have placed this directive in the "li" tag.

Also, it would be prettier to create a single list and add multiple items to that list rather than have multiple lists with a single item.

