### PR TITLE
update api-reference.md (authentication usage)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -199,15 +199,32 @@ import {FirebaseAuth} from 'angularfire2';
 @Component({
   selector: 'auth-status',
   template: `
-    <div *ng-if="auth | async">You are logged in</div>
-    <div *ng-if="!(auth | async)">Please log in</div>
+    <div *ngIf="auth | async">You are logged in</div>
+    <div *ngIf="!(auth | async)">Please log in</div>
   `
 })
 class App {
   constructor (@Inject(FirebaseAuth) public auth: FirebaseAuth) {}
 }
 ```
+Alternatively, if you wish to extend an existing AngularFire component to monitor authentication status:
+```
+ts
+import {AngularFire, FirebaseAuth} from 'angularfire2';
+@Component({
+  selector: 'auth-status',
+  template: `
+    <div *ngIf="af.auth | async">You are logged in</div>
+    <div *ngIf="!(af.auth | async)">Please log in</div>
+  `
+})
+class App {
+  constructor(public af: AngularFire) {
+    this.af.auth.subscribe(auth => console.log(auth));
+  }
+}
 
+```
 ### FirebaseListObservable
 
 Subclass of rxjs `Observable` which also has methods for updating


### PR DESCRIPTION
under: Subscribing to Authentication State
`*ng-if` was replaced with `*ngIf` (the correct Angular2 syntax)
an extra usage was added to make it more fluid for components with AngularFire already, instead of a new component for FirebaseAuth. Fits in better with https://github.com/angular/angularfire2/blob/master/docs/5-user-authentication.md
Finally, not sure if `@Inject(FirebaseAuth)` is necessary as it seems to work without it on my machine, but left it in the original usage (would probably also have to include an import statement for it in the original usage; I'll leave that to the original author.