### PR TITLE
docs(3-retrieving-data-as-lists.md): clarity and FirebaseListObservable correction

### DIFF
--- a/docs/3-retrieving-data-as-lists.md
+++ b/docs/3-retrieving-data-as-lists.md
@@ -152,13 +152,13 @@ import { AngularFire, FirebaseListObservable, FirebaseObjectObservable } from 'a
   template: `
   <ul>
     <li *ngFor="let item of items | async">
-      <input type="text" #updatesize [value]="item.text" />
-      <button (click)="update(item.$key, updatesize.value)">Update</button>
+      <input type="text" #updatetext [value]="item.text" />
+      <button (click)="updateItem(item.$key, updatetext.value)">Update</button>
       <button (click)="deleteItem(item.$key)">Delete</button>
     </li>
   </ul>
   <input type="text" #newitem />
-  <button (click)="add(newitem.value)">Add</button>
+  <button (click)="addItem(newitem.value)">Add</button>
   <button (click)="deleteEverything()">Delete All</button>
   `,
 })
@@ -167,11 +167,11 @@ export class RcTestAppComponent {
   constructor(af: AngularFire) {
     this.items = af.database.list('/messages');
   }
-  add(newName: string) {
+  addItem(newName: string) {
     this.items.push({ text: newName });
   }
-  update(key: string, newSize: string) {
-    this.items.update(key, { size: newSize });
+  updateItem(key: string, newText: string) {
+    this.items.update(key, { text: newText });
   }
   deleteItem(key: string) {    
     this.items.remove(key); 

--- a/docs/3-retrieving-data-as-lists.md
+++ b/docs/3-retrieving-data-as-lists.md
@@ -69,7 +69,7 @@ import {AngularFire, FirebaseListObservable} from 'angularfire2';
   `,
 })
 class AppComponent {
-  items: Observable<any>;
+  items: FirebaseListObservable<any>;
   constructor(af: AngularFire) {
     this.items = af.database.list('/items');
   }
@@ -80,7 +80,7 @@ class AppComponent {
 
 ### API Summary
 
-The table below highlights some of the common methods on the `FirebaseObjectObservable`.
+The table below highlights some of the common methods on the `FirebaseListObservable`.
 
 | method   |                    | 
 | ---------|--------------------| 


### PR DESCRIPTION
Update 'Observable' and 'FirebaseObjectObservable' to 'FirebaseListObservable' where needed.

Update component methods to be prefixed by 'Item'. This prevents collisions, and improves readability, in situations where the previous step's example is combined with this one.

Update field being updated from size to text. This allows the updates to be immediately observable without any additional code, since item.size was not being displayed.