### PR TITLE
chore(peerDependencies): use tilde for matching peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   },
   "homepage": "https://github.com/angular/angularfire2#readme",
   "dependencies": {
-    "@angular/core": "2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8 || 2.0.0-rc.9",
-    "@angular/platform-browser": "2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8 || 2.0.0-rc.9",
-    "@angular/common": "2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8 || 2.0.0-rc.9",
-    "@angular/compiler": "2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8 || 2.0.0-rc.9",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.2 || 2.0.0-rc.3 || 2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6 || 2.0.0-rc.7 || 2.0.0-rc.8 || 2.0.0-rc.9",
+    "@angular/core": "^2.0.0-rc.2",
+    "@angular/platform-browser": "^2.0.0-rc.2",
+    "@angular/common": "^2.0.0-rc.2",
+    "@angular/compiler": "^2.0.0-rc.2",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.2",
     "firebase": "^3.0.3",
     "rxjs": "5.0.0-beta.6"
   },

--- a/tsconfig.publish.es5.json
+++ b/tsconfig.publish.es5.json
@@ -14,7 +14,7 @@
   },
   "files": [
     "src/angularfire2.ts",
-    "typings/main.d.ts",
+    "typings/index.d.ts",
     "manual_typings/firebase3/firebase3.d.ts"
   ]
 }


### PR DESCRIPTION
We can use tilde for the project's dependencies and respectively for the project's `peerDependencies` once published. Verified by @jeffbcross and me [here](https://github.com/angular/mobile-toolkit/pull/79).

The PR has also a fix for the main file that contains references to all the ambient type definitions installed with typings 1.3.2.