### PR TITLE
Fix the syntax for an example in user-authentication docs.

### DIFF
--- a/docs/5-user-authentication.md
+++ b/docs/5-user-authentication.md
@@ -78,7 +78,7 @@ import { AngularFire } from 'angularfire2';
   moduleId: module.id,
   selector: 'app',
   template: `
-  <div> {{ (af.auth | async).uid }} </div>
+  <div> {{ (af.auth | async)?.uid }} </div>
   <button (click)="login()">Login</button>
   `,
 })


### PR DESCRIPTION
* Fix the syntax to fetch the correct authencation response.
* With the current syntax an exception is thrown: "cannot read property null of uid"