### PR TITLE
fix(auth): Auth config for initializeApp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularfire2",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3-pre",
   "description": "",
   "main": "./dist/angularfire2.js",
   "jsnext:main": "./dist/esm/angularfire2.js",
@@ -9,8 +9,8 @@
     "test:watch": "karma start",
     "build": "rm -rf dist; tsc",
     "build:watch": "rm -rf dist && tsc -w",
-    "build_npm": "rm -rf dist && ngc -p tsconfig.publish.es5.json && ngc -p tsconfig.publish.es6.json",
-    "postbuild_npm": "cp manual_typings/firebase3/firebase3.d.ts package.json README.md .npmignore dist/ && npm run rewrite_npm_package",
+    "build_npm": "rm -rf dist && ngc -p tsconfig.publish.es5.json && ngc -p tsconfig.publish.es6.json && npm run postbuild_npm",
+    "postbuild_npm": "cp package.json README.md .npmignore dist/ && npm run rewrite_npm_package",
     "rewrite_npm_package": "node --harmony_destructuring tools/rewrite-published-package.js",
     "e2e_test": "webdriver-manager update && npm run build_e2e && protractor",
     "build_e2e": "rm -rf dist-test && npm run build && tsc -p test/ && cp test/e2e/firebase_object/index.html dist-test/e2e/firebase_object/ && cp test/e2e/firebase_list/index.html dist-test/e2e/firebase_list/ && cp test/e2e/auth/index.html dist-test/e2e/auth/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularfire2",
-  "version": "2.0.0-beta.3-pre",
+  "version": "2.0.0-beta.2",
   "description": "",
   "main": "./dist/angularfire2.js",
   "jsnext:main": "./dist/esm/angularfire2.js",

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase';
 import * as utils from './utils';
 import { FirebaseAppConfig } from './interfaces';
+import { AuthConfiguration } from './auth';
 import {
   FirebaseListFactoryOpts,
   FirebaseObjectFactoryOpts,
@@ -109,7 +110,7 @@ export const defaultFirebase = (config: FirebaseAppConfig): any => {
 	providers: FIREBASE_PROVIDERS
 })
 export class AngularFireModule {
-  static initializeApp(config: FirebaseAppConfig, authConfig?:FirebaseAppConfig): ModuleWithProviders {
+  static initializeApp(config: FirebaseAppConfig, authConfig?:AuthConfiguration): ModuleWithProviders {
     return {
 		ngModule: AngularFireModule,
 		providers: [

--- a/src/auth/auth_backend.ts
+++ b/src/auth/auth_backend.ts
@@ -37,8 +37,6 @@ export enum AuthMethods {
 export interface AuthConfiguration {
   method?: AuthMethods;
   provider?: AuthProviders;
-  remember?: string;
-  scope?: string[];
 }
 
 export interface FirebaseAuthState {


### PR DESCRIPTION
Correcting the auth type used in `AngularFireModule.initializeApp(config: FirebaseAppConfig, auth: AuthConfiguration)`.