### PR TITLE
feat(utils): Add $exists method to AFUnwrappedSnapshot

### DIFF
--- a/src/auth/auth_backend.ts
+++ b/src/auth/auth_backend.ts
@@ -37,6 +37,7 @@ export enum AuthMethods {
 export interface AuthConfiguration {
   method?: AuthMethods;
   provider?: AuthProviders;
+  scope?: string[];
 }
 
 export interface FirebaseAuthState {

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -524,7 +524,7 @@ describe('FirebaseListFactory', () => {
         val: () => val
       };
 
-      fit('should return an object value with a $key property', () => {
+      it('should return an object value with a $key property', () => {
         const unwrapped = utils.unwrapMapFn(snapshot as firebase.database.DataSnapshot);
         expect(unwrapped.$key).toEqual(snapshot.ref.key);
       });

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -534,18 +534,22 @@ describe('FirebaseListFactory', () => {
 
 
       it('should return an object value with a $value property if value is scalar', () => {
-        expect(utils.unwrapMapFn(Object.assign(snapshot, { val: () => 5 }) as firebase.database.DataSnapshot)).toEqual({
-          $key: 'key',
-          $value: 5
-        });
-        expect(utils.unwrapMapFn(Object.assign(snapshot, { val: () => false }) as firebase.database.DataSnapshot)).toEqual({
-          $key: 'key',
-          $value: false
-        });
-        expect(utils.unwrapMapFn(Object.assign(snapshot, { val: () => 'lol' }) as firebase.database.DataSnapshot)).toEqual({
-          $key: 'key',
-          $value: 'lol'
-        });
+        const existsFn = () => { return true; }
+        const unwrappedValue5 = utils.unwrapMapFn(Object.assign(snapshot, { val: () => 5, exists: existsFn }) as firebase.database.DataSnapshot);
+        const unwrappedValueFalse = utils.unwrapMapFn(Object.assign(snapshot, { val: () => false, exists: existsFn }) as firebase.database.DataSnapshot);
+        const unwrappedValueLol = utils.unwrapMapFn(Object.assign(snapshot, { val: () => 'lol', exists: existsFn }) as firebase.database.DataSnapshot);
+
+        expect(unwrappedValue5.$key).toEqual('key');
+        expect(unwrappedValue5.$value).toEqual(5);
+        expect(unwrappedValue5.$exists()).toEqual(true);
+
+        expect(unwrappedValueFalse.$key).toEqual('key');
+        expect(unwrappedValueFalse.$value).toEqual(false);
+        expect(unwrappedValueFalse.$exists()).toEqual(true);
+
+        expect(unwrappedValueLol.$key).toEqual('key');
+        expect(unwrappedValueLol.$value).toEqual('lol');
+        expect(unwrappedValueLol.$exists()).toEqual(true);        
       });
     });
 

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -13,15 +13,15 @@ import {
   defaultFirebase,
   FirebaseApp,
   FirebaseAppConfig,
-  AngularFire
+  AngularFire,
 } from '../angularfire2';
 import {
   addProviders,
   inject
 } from '@angular/core/testing';
 import * as utils from '../utils';
-import {Query} from '../interfaces';
-import {Subscription, Observable, Subject} from 'rxjs';
+import { Query, AFUnwrappedDataSnapshot } from '../interfaces';
+import { Subscription, Observable, Subject } from 'rxjs';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/skip';
 import 'rxjs/add/operator/take';
@@ -524,14 +524,10 @@ describe('FirebaseListFactory', () => {
         val: () => val
       };
 
-      it('should return an object value with a $key property', () => {
+      fit('should return an object value with a $key property', () => {
         const unwrapped = utils.unwrapMapFn(snapshot as firebase.database.DataSnapshot);
-        expect(unwrapped).toEqual({
-          $key: 'key',
-          unwrapped: true
-        });
+        expect(unwrapped.$key).toEqual(snapshot.ref.key);
       });
-
 
       it('should return an object value with a $value property if value is scalar', () => {
         const existsFn = () => { return true; }

--- a/src/database/firebase_object_factory.spec.ts
+++ b/src/database/firebase_object_factory.spec.ts
@@ -71,18 +71,24 @@ describe('FirebaseObjectFactory', () => {
 
 
     it('should emit a null value if no value is present when subscribed', (done: any) => {
-      subscription = observable.subscribe(val => {
-        expect(val).toEqual({ $key: (<any>observable)._ref.key, $value: null });
+      subscription = observable.subscribe(unwrapped => {
+        const expectedObject = { $key: (<any>observable)._ref.key, $value: null };
+        expect(unwrapped.$key).toEqual(expectedObject.$key);
+        expect(unwrapped.$value).toEqual(expectedObject.$value);
+        expect(unwrapped.$exists()).toEqual(false);
         done();
       });
     });
 
 
     it('should emit unwrapped data by default', (done: any) => {
-      ref.set({ unwrapped: 'bar' }, () => {
-        subscription = observable.subscribe(val => {
-          if (!val) return;
-          expect(val).toEqual({ $key: ref.key, unwrapped: 'bar' });
+      ref.set({ data: 'bar' }, () => {
+        subscription = observable.subscribe(unwrapped => {
+          if (!unwrapped) return;
+          const expectedObject = { $key: ref.key, data: 'bar' };
+          expect(unwrapped.$key).toEqual(expectedObject.$key);
+          expect(unwrapped.data).toEqual(expectedObject.data);
+          expect(unwrapped.$exists()).toEqual(true);
           done();
         });
       });

--- a/src/database/firebase_object_factory.spec.ts
+++ b/src/database/firebase_object_factory.spec.ts
@@ -88,16 +88,27 @@ describe('FirebaseObjectFactory', () => {
       });
     });
 
-   it('should emit unwrapped data with a $value property for primitive values', (done: any) => {
+   it('should emit unwrapped data with $ properties for primitive values', (done: any) => {
       ref.set('fiiiireeee', () => {
         subscription = observable.subscribe(val => {
           if (!val) return;
-          expect(val).toEqual({ $key: ref.key, $value: 'fiiiireeee' });
+          expect(val.$key).toEqual(ref.key);
+          expect(val.$value).toEqual('fiiiireeee');
+          expect(val.$exists()).toEqual(true);
           done();
         });
       });
     });
 
+   it('should emit null for $ properties for primitive values', (done: any) => {
+     subscription = observable.subscribe(val => {
+       if (!val) return;
+       expect(val.$key).toEqual(ref.key);
+       expect(val.$value).toEqual(null);
+       expect(val.$exists()).toEqual(false);
+       done();
+     });
+    });
 
     it('should emit snapshots if preserveSnapshot option is true', (done: any) => {
       observable = FirebaseObjectFactory(`${rootFirebase}/questions/${i}`, { preserveSnapshot: true });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,6 +17,7 @@ export interface FirebaseOperationCases {
 export interface AFUnwrappedDataSnapshot {
   $key: string;
   $value?: string | number | boolean;
+  $exists: () => boolean;
 }
 
 export interface Query {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,17 @@ export interface CheckUrlRef {
   isQuery?: () => any;
 }
 
+/**
+ * Unwraps the data returned in the DataSnapshot. Exposes the DataSnapshot key
+ * and exists methods through the $key and $exists properties respectively.
+ * If the value is primitive, it is unwrapped using a $value property. The $ 
+ * properies mean they cannot be saved in the Database as those characters 
+ * are invalid. 
+ * @param {DataSnapshot} snapshot - The snapshot to unwrap
+ * @return AFUnwrappedDataSnapshot
+ * @example
+ * unwrapMapFn(snapshot) => { name: 'David', $key: 'david', $exists: Function }
+ */
 export function unwrapMapFn (snapshot:firebase.database.DataSnapshot): AFUnwrappedDataSnapshot {
   var unwrapped = isPresent(snapshot.val()) ? snapshot.val() : { $value: null };
   if ((/string|number|boolean/).test(typeof unwrapped)) {
@@ -46,6 +57,9 @@ export function unwrapMapFn (snapshot:firebase.database.DataSnapshot): AFUnwrapp
     };
   }
   unwrapped.$key = snapshot.ref.key;
+  unwrapped.$exists = () => {
+    return snapshot.exists();
+  };
   return unwrapped;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,11 +39,7 @@ export interface CheckUrlRef {
 }
 
 /**
- * Unwraps the data returned in the DataSnapshot. Exposes the DataSnapshot key
- * and exists methods through the $key and $exists properties respectively.
- * If the value is primitive, it is unwrapped using a $value property. The $ 
- * properies mean they cannot be saved in the Database as those characters 
- * are invalid. 
+ * Unwraps the data returned in the DataSnapshot. Exposes the DataSnapshot key and exists methods through the $key and $exists properties respectively. If the value is primitive, it is unwrapped using a $value property. The $ properies mean they cannot be saved in the Database as those characters are invalid. 
  * @param {DataSnapshot} snapshot - The snapshot to unwrap
  * @return AFUnwrappedDataSnapshot
  * @example


### PR DESCRIPTION
Closes` #300. Also closes #464.

Exposes the `DataSnapshot#exists` function to the `AFUnwrappedSnapshot`.

```ts
af.database.object('myKey').subscribe((obj) => {
  if (obj.$exists()) {
    // object exists
  } else {
   // object does not exist
  }
});
```