### PR TITLE
fix(docs): Fix user auth code example that throws an exception

### DIFF
--- a/docs/5-user-authentication.md
+++ b/docs/5-user-authentication.md
@@ -113,6 +113,10 @@ af.auth.login({
 
 // Email and password
 af.auth.login({
+  email: 'email@example.com',
+  password: 'password',
+},
+{
   provider: AuthProviders.Password,
   method: AuthMethods.Password,
 })


### PR DESCRIPTION
Corrected signature in docs for overriding user auth with `AuthMethods.Password`

See #336.