### PR TITLE
Updated selector name in app.component.ts

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -97,7 +97,7 @@ import { AngularFire, FirebaseListObservable } from 'angularfire2';
 
 @Component({
   moduleId: module.id,
-  selector: 'root-app',
+  selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.css']
 })
@@ -119,7 +119,7 @@ import { AngularFire, FirebaseListObservable } from 'angularfire2';
 
 @Component({
   moduleId: module.id,
-  selector: 'root-app',
+  selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.css']
 })


### PR DESCRIPTION
Just noticed. minor change, but important. changed the selector in "app.component.ts" to match the selector in the index.html. 
They were reversely named(<app-root> vs <root-app>).