### PR TITLE
Update 1 - Install and Setup.md

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -96,7 +96,6 @@ import { Component } from '@angular/core';
 import { AngularFire, FirebaseListObservable } from 'angularfire2';
 
 @Component({
-  moduleId: module.id,
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.css']
@@ -118,7 +117,6 @@ import { Component } from '@angular/core';
 import { AngularFire, FirebaseListObservable } from 'angularfire2';
 
 @Component({
-  moduleId: module.id,
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.css']


### PR DESCRIPTION
 'moduleId: module.id' is causing errors 
"url_resolver.js:248Uncaught TypeError: uri.match is not a function_split @ 
url_resolver.js:248getUrlScheme @ url_resolver.js:91componentModuleUrl @ ".

Removed it from docs as the default angular-app does not contains an entry.  I need to learn to consolidate small changes.