### PR TITLE
Updated package.json to use the correct casing for the 'main' entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angularfire2",
   "version": "2.0.0-beta.5",
   "description": "",
-  "main": "bundles/angularFire2.umd.js",
+  "main": "bundles/angularfire2.umd.js",
   "module": "index.js",
   "scripts": {
     "test": "npm run build; karma start --single-run",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angularfire2",
   "version": "2.0.0-beta.5",
   "description": "",
-  "main": "bundles/angularfire2.umd.js",
+  "main": "bundles/angularFire2.umd.js",
   "module": "index.js",
   "scripts": {
     "test": "npm run build; karma start --single-run",

--- a/rollup.publish.config.js
+++ b/rollup.publish.config.js
@@ -2,7 +2,7 @@ import globals from './rollup-globals';
 
 export default {
   entry: 'dist/index.js',
-  dest: 'dist/bundles/angularFire2.umd.js',
+  dest: 'dist/bundles/angularfire2.umd.js',
   format: 'umd',
   moduleName: 'angularFire2',
   globals


### PR DESCRIPTION
In the rollup script 'angularFire2.umd.js'  is used, where in the package.json 'angularfire2.umd.js' was used, causing for loading problems on linux based systems (Ubuntu in this case)

[https://github.com/angular/angularfire2/blob/master/rollup.publish.config.js#L5](url)