### PR TITLE
docs(authentication): Add logout() method to guide.

### DIFF
--- a/docs/5-user-authentication.md
+++ b/docs/5-user-authentication.md
@@ -101,9 +101,7 @@ export class RcTestAppComponent {
 
 ## Logout users
 
-`logout()` : Removes the Firebase refernece, similar to [firebase-signout](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signOut)
-
-All you need to do is call logout on `af.auth.logout()`
+Deletes the authentication token issued by Firebase and signs user out. See [Auth.signOut()](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signOut) in the Firebase API reference.
 
 Sample Usage:
 
@@ -112,7 +110,6 @@ Sample Usage:
 		this.af.auth.logout();
 	}
 ```
-
 
 ## Override configuration / No config
 

--- a/docs/5-user-authentication.md
+++ b/docs/5-user-authentication.md
@@ -99,6 +99,21 @@ export class RcTestAppComponent {
 }
 ```
 
+## Logout users
+
+`logout()` : Removes the Firebase refernece, similar to [firebase-signout](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signOut)
+
+All you need to do is call logout on `af.auth.logout()`
+
+Sample Usage:
+
+```ts
+	signOut(): {
+		this.af.auth.logout();
+	}
+```
+
+
 ## Override configuration / No config
 
 Authentication works without configuration, and even if you have setup 


### PR DESCRIPTION
There is no reference to the `logout()` function in the documentation file **5-user-authentication.md**.
Would have liked to add this to the **api-reference.md** file too, but someone has already submitted an extensive updated PR for the same. 