### PR TITLE
docs(contributing): Fixed link to CONTRIBUTING renamed at commit ea80969

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Status: Beta
 - **Authentication** - Monitor authentication state in realtime.
 
 #### Quick links
-[Contributing](https://github.com/angular/angularfire2/blob/master/CONTRIBUTOR.md)
+[Contributing](https://github.com/angular/angularfire2/blob/master/CONTRIBUTING.md)
 
 [Plunker Template](http://plnkr.co/edit/4IbB5IvfkBYcj2iVAIM1?p=preview) - Requires to set your Firebase credentials in `app.module.ts`.
 


### PR DESCRIPTION
Simple fix of broken link in README.md broken after rename of CONTRIBUTOR.md to CONTRIBUTING.md