### PR TITLE
docs(auth): add imports for AuthProviders and AuthMethods

### DIFF
--- a/docs/5-user-authentication.md
+++ b/docs/5-user-authentication.md
@@ -11,6 +11,10 @@ To specify your authentication ahead of time, you provide the `AngularFireModule
 with an `AuthProvider` and an `AuthMethod`.
 
 ```ts
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+import { AppComponent } from './app.component';
+import { AngularFireModule, AuthProviders, AuthMethods } from 'angularfire2';
 
 const myFirebaseConfig = {
   apiKey: '<your-key>',
@@ -29,10 +33,10 @@ const myFirebaseAuthConfig = {
     BrowserModule,
     AngularFireModule.initializeApp(myFirebaseConfig, myFirebaseAuthConfig)
   ],
-  declarations: [ MyComponent ],
-  boostrap: [ MyComponent ]
+  declarations: [ AppComponent ],
+  bootstrap: [ AppComponent ]
 })
-export class MyAppModule {}
+export class AppModule {}
 ```
 
 


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: https://github.com/angular/angularfire2/issues/627
   - Docs included?: yes
   - Test units included?: no, no code change
   - e2e tests included?: no, no code change
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

On first reading the Auth docs while doing the RC.4 to 2.1.0 upgrade and coming from angularfire2 beta.2 to beta.5, it was confusing if there was some new way to getting AuthProviders and AuthMethods. I was wondering if these come from the AngularFireModule now or if they came from a service or something. It would have saved me a lot of confusion to just specify that that they are still imported from angularfire2 like before. I.e. `import { AngularFireModule, AuthProviders, AuthMethods } from 'angularfire2';`

Also use AppComponent and AppModule for consistency with other docs.
Also fix typo of `boostrap` to `bootstrap`.

Fixes #627.