### PR TITLE
Change logout methods to return a promise

### DIFF
--- a/docs/5-user-authentication.md
+++ b/docs/5-user-authentication.md
@@ -69,7 +69,7 @@ import { AngularFire } from 'angularfire2';
 export class AppComponent {
   constructor(public af: AngularFire) {}
  
- login() {
+  login() {
     this.af.auth.login();
   }
   

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -318,15 +318,15 @@ constructor(public auth: FirebaseAuth) {
     }
 ```
 
-`logout(): void`: Deletes the authentication token issued by Firebase and signs user out. See [Auth.signOut()](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signOut) for more information.
-
-*It is worth noting that logout() is an asynchronous operation. There is an open bug against the Firebase SDK to make this return a promise.*
+`logout(): Promise<void>`: Deletes the authentication token issued by Firebase and signs user out. See [Auth.signOut()](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signOut) for more information.
 
 Sample Usage:
 
 ```ts
 	signOut(): {
-		this.af.auth.logout();
+		this.af.auth.logout().then(() => {
+			// user logged out
+		});
 	}
 ```
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -119,8 +119,8 @@ export class AngularFireAuth extends ReplaySubject<FirebaseAuthState> {
     }
   }
 
-  public logout(): void {
-    this._authBackend.unauth();
+  public logout(): Promise<void> {
+    return this._authBackend.unauth();
   }
 
   public getAuth(): FirebaseAuthState {

--- a/src/auth/auth_backend.ts
+++ b/src/auth/auth_backend.ts
@@ -11,7 +11,7 @@ export abstract class AuthBackend {
     : Promise<FirebaseAuthState>;
   abstract onAuth(): Observable<FirebaseAuthState>;
   abstract getAuth(): FirebaseAuthState;
-  abstract unauth(): void;
+  abstract unauth(): Promise<void>;
   abstract createUser(credentials: EmailPasswordCredentials): Promise<FirebaseAuthState>;
   abstract getRedirectResult(): Observable<firebase.auth.UserCredential>;
 }

--- a/src/auth/firebase_sdk_auth_backend.ts
+++ b/src/auth/firebase_sdk_auth_backend.ts
@@ -67,8 +67,8 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
     return observeOn.call(authState, new ZoneScheduler(Zone.current));
   }
 
-  unauth(): void {
-    Promise.resolve(this._fbAuth.signOut());
+  unauth(): Promise<void> {
+    return <Promise<void>>this._fbAuth.signOut();
   }
 
   authWithCustomToken(token: string): Promise<FirebaseAuthState> {


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #583 (required)
   - Docs included?: yes
   - Test units included?: no
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

- Change the `AuthBackend.unauth()` method to return the value of the `_authBackend.unauth` call
- Change the `FirebaseSdkAuthBackend.unauth()` method to return a promise instead of `void` to match the [API](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#signOut) as suggested in #583

### Code sample

```js
this.auth$.logout().then(() => {
  console.log('Logged out!');
});
```