### PR TITLE
fix(database): removed unused query option

### DIFF
--- a/docs/2-retrieving-data-as-objects.md
+++ b/docs/2-retrieving-data-as-objects.md
@@ -188,6 +188,4 @@ this.item.subscribe(snapshot => {
 
 Because `FirebaseObjectObservable` synchronizes objects from the realtime database, sorting will have no effect for queries that are not also limited by a range. For example, when paginating you would provide a query with a sort and filter. Both the sort operation and the filter operation affect which subset of the data is returned by the query; however, because the resulting object is simply json, the sort order will not be preseved locally. Hence, for operations that require sorting, you are probably looking for a [list](3-retrieving-data-as-lists.md)
 
-For filtering response data see [](4-querying-lists.md) and repeat 'Object' to yourself everytime you read the word 'List'. 
-
 ###[Next Step: Retrieving data as lists](3-retrieving-data-as-lists.md)

--- a/src/database/firebase_object_factory.ts
+++ b/src/database/firebase_object_factory.ts
@@ -3,13 +3,11 @@ import { Observer } from 'rxjs/Observer';
 import { observeOn } from 'rxjs/operator/observeOn';
 import * as firebase from 'firebase';
 import * as utils from '../utils';
-import { Query } from '../interfaces';
-import { observeQuery } from './query_observable';
 import { FirebaseObjectFactoryOpts } from '../interfaces';
 
 export function FirebaseObjectFactory (
   absoluteUrlOrDbRef: string | firebase.database.Reference,
-  { preserveSnapshot, query }: FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
+  { preserveSnapshot }: FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
 
   let ref: firebase.database.Reference;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,7 +65,6 @@ export interface FirebaseListFactoryOpts {
 
 export interface FirebaseObjectFactoryOpts {
   preserveSnapshot?: boolean;
-  query?: Query
 }
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #706
   - Docs included?: yes 
   - Test units included?: no 
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? no

The in-a-clean-directory thing doesn't work for me; I blame Windows. (And my Mac is packed up, as we are moving house.)

### Description

This PR removes a misleading (and malformed) comment in the `FirebaseObjectObservable` documentation that suggests the `query` option can be used in a manner similar to that for the `FirebaseListObservable`. It cannot be, as the option is ignored `FirebaseObjectObservable` factory's implementation.

This PR also removes the ignored `query` option so that TypeScript-based tools don't suggest it and so that any existing usage of the option will fail with a type error rather than behave unexpectedly.