### PR TITLE
docs(api-reference) typo

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -268,8 +268,7 @@ class App {
 }
 ```
 Alternatively, if you wish to extend an existing AngularFire component to monitor authentication status:
-```
-ts
+```ts
 import {AngularFire, FirebaseAuth} from 'angularfire2';
 @Component({
   selector: 'auth-status',


### PR DESCRIPTION
removed line break at 271 which was breaking syntax highlighting for that code block