### PR TITLE
fix(list): Work around Firebase SDK sync quirk #574

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,6 +34,7 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
+    reporters: ['mocha'],
     singleRun: false
   })
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "index.js",
   "scripts": {
     "test": "npm run build && karma start --single-run",
+    "test:debug": "npm run build && karma start",
     "test:watch": "concurrently \"npm run build:watch\" \"npm run delayed_karma\"",
     "delayed_karma": "sleep 10 && karma start",
     "delayed_rollup": "sleep 5 && rollup --watch -c rollup.test.config.js",

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -377,16 +377,16 @@ describe('FirebaseListFactory', () => {
 
 
     it('should emit only when the initial data set has been loaded', (done: any) => {
-      (<any>questions).$ref.set([{ initial1: true }, { initial2: true }, { initial3: true }, { initial4: true }])
+      questions.$ref.ref.set([{ initial1: true }, { initial2: true }, { initial3: true }, { initial4: true }])
         .then(() => toPromise.call(skipAndTake(questions, 1)))
         .then((val: any[]) => {
+          console.log(val);
           expect(val.length).toBe(4);
         })
         .then(() => {
           done();
         }, done.fail);
     });
-
 
     it('should emit a new value when a child moves', (done: any) => {
        let question = skipAndTake(questions, 1, 2)
@@ -433,16 +433,16 @@ describe('FirebaseListFactory', () => {
       });
     });
 
-
-    it('should call off on all events when disposed', () => {
+    it('should call off on all events when disposed', (done: any) => {
       const questionRef = firebase.database().ref().child('questions');
       var firebaseSpy = spyOn(questionRef, 'off').and.callThrough();
-      subscription = FirebaseListFactory(questionRef).subscribe();
-      expect(firebaseSpy).not.toHaveBeenCalled();
-      subscription.unsubscribe();
-      expect(firebaseSpy).toHaveBeenCalled();
+      subscription = FirebaseListFactory(questionRef).subscribe(() => {
+        expect(firebaseSpy).not.toHaveBeenCalled();
+        subscription.unsubscribe();
+        expect(firebaseSpy).toHaveBeenCalled();
+        done();
+      });
     });
-
 
     describe('onChildAdded', () => {
       it('should add the child after the prevKey', () => {

--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -8,12 +8,13 @@ import { Query, FirebaseListFactoryOpts } from '../interfaces';
 import * as utils from '../utils';
 import { mergeMap } from 'rxjs/operator/mergeMap';
 import { map } from 'rxjs/operator/map';
+import { Observable } from 'rxjs/Observable';
 
-export function FirebaseListFactory (
-  absoluteUrlOrDbRef:string |
-  firebase.database.Reference |
-  firebase.database.Query,
-  {preserveSnapshot, query = {}}:FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
+export function FirebaseListFactory(
+  absoluteUrlOrDbRef: string |
+    firebase.database.Reference |
+    firebase.database.Query,
+  {preserveSnapshot, query = {}}: FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
 
   let ref: firebase.database.Reference | firebase.database.Query;
 
@@ -25,8 +26,8 @@ export function FirebaseListFactory (
 
   // if it's just a reference or string, create a regular list observable
   if ((utils.isFirebaseRef(absoluteUrlOrDbRef) ||
-       utils.isString(absoluteUrlOrDbRef)) &&
-       utils.isEmptyObject(query)) {
+    utils.isString(absoluteUrlOrDbRef)) &&
+    utils.isEmptyObject(query)) {
     return firebaseListObservable(ref, { preserveSnapshot });
   }
 
@@ -70,11 +71,11 @@ export function FirebaseListFactory (
 
       // check startAt
       if (utils.hasKey(query, "startAt")) {
-          queried = queried.startAt(query.startAt);
+        queried = queried.startAt(query.startAt);
       }
 
       if (utils.hasKey(query, "endAt")) {
-          queried = queried.endAt(query.endAt);
+        queried = queried.endAt(query.endAt);
       }
 
       if (!utils.isNil(query.limitToFirst) && query.limitToLast) {
@@ -83,88 +84,129 @@ export function FirebaseListFactory (
 
       // apply limitTos
       if (!utils.isNil(query.limitToFirst)) {
-          queried = queried.limitToFirst(query.limitToFirst);
+        queried = queried.limitToFirst(query.limitToFirst);
       }
 
       if (!utils.isNil(query.limitToLast)) {
-          queried = queried.limitToLast(query.limitToLast);
+        queried = queried.limitToLast(query.limitToLast);
       }
 
       return queried;
     }), (queryRef: firebase.database.Reference, ix: number) => {
       return firebaseListObservable(queryRef, { preserveSnapshot });
     })
-    .subscribe(subscriber);
+      .subscribe(subscriber);
 
     return () => sub.unsubscribe();
   });
 }
 
+/**
+ * Creates a FirebaseListObservable from a reference or query. Options can be provided as a second parameter.
+ * This function understands the nuances of the Firebase SDK event ordering and other quirks. This function
+ * takes into account that not all .on() callbacks are guaranteed to be asynchonous. It creates a initial array
+ * from a promise of ref.once('value'), and then starts listening to child events. When the initial array
+ * is loaded, the observable starts emitting values.
+ */
 function firebaseListObservable(ref: firebase.database.Reference | firebase.database.Query, {preserveSnapshot}: FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
-
+  // Keep track of callback handles for calling ref.off(event, handle)
+  const handles = [];
   const listObs = new FirebaseListObservable(ref, (obs: Observer<any[]>) => {
-    let arr: any[] = [];
-    let hasInitialLoad = false;
-    // The list should only emit after the initial load
-    // comes down from the Firebase database, (e.g.) all
-    // the initial child_added events have fired.
-    // This way a complete array is emitted which leads
-    // to better rendering performance
-    ref.once('value', (snap) => {
-      hasInitialLoad = true;
-      obs.next(preserveSnapshot ? arr : arr.map(utils.unwrapMapFn));
-    }).catch(err => {
-      obs.error(err);
-      obs.complete()
-    });
+    ref.once('value')
+      .then((snap) => {
+        let initialArray = [];
+        snap.forEach(child => {
+          initialArray.push(child)
+        });
+        return initialArray;
+      })
+      .then((initialArray) => {
+        const isInitiallyEmpty = initialArray.length === 0;
+        let hasInitialLoad = false;
+        let lastKey;
 
-    let addFn = ref.on('child_added', (child: any, prevKey: string) => {
-      arr = onChildAdded(arr, child, prevKey);
-      // only emit the array after the initial load
-      if (hasInitialLoad) {
-        obs.next(preserveSnapshot ? arr : arr.map(utils.unwrapMapFn));
-      }
-    }, err => {
-      if (err) { obs.error(err); obs.complete(); }
-    });
+        if (!isInitiallyEmpty) {
+          // The last key in the initial array tells us where
+          // to begin listening in realtime
+          lastKey = initialArray[initialArray.length - 1].key;
+        }
 
-    let remFn = ref.on('child_removed', (child: any) => {
-      arr = onChildRemoved(arr, child)
-      if (hasInitialLoad) {
-        obs.next(preserveSnapshot ? arr : arr.map(utils.unwrapMapFn));
-      }
-    }, err => {
-      if (err) { obs.error(err); obs.complete(); }
-    });
+        const addFn = ref.on('child_added', (child: any, prevKey: string) => {
+          // If the initial load has not been set and the current key is
+          // the last key of the initialArray, we know we have hit the
+          // initial load
+          if (!isInitiallyEmpty) {
+            if (child.key === lastKey) {
+              hasInitialLoad = true;
+              obs.next(preserveSnapshot ? initialArray : initialArray.map(utils.unwrapMapFn));
+              return;
+            }
+          }
 
-    let chgFn = ref.on('child_changed', (child: any, prevKey: string) => {
-      arr = onChildChanged(arr, child, prevKey)
-      if (hasInitialLoad) {
-        // This also manages when the only change is prevKey change
-        obs.next(preserveSnapshot ? arr : arr.map(utils.unwrapMapFn));
-      }
-    }, err => {
-      if (err) { obs.error(err); obs.complete(); }
-    });
+          if (hasInitialLoad) {
+            initialArray = onChildAdded(initialArray, child, prevKey);
+          }
+
+          // only emit the array after the initial load
+          if (hasInitialLoad) {
+            obs.next(preserveSnapshot ? initialArray : initialArray.map(utils.unwrapMapFn));
+          }
+        }, err => {
+          if (err) { obs.error(err); obs.complete(); }
+        });
+
+        handles.push({ event: 'child_added', handle: addFn });
+
+        let remFn = ref.on('child_removed', (child: any) => {
+          initialArray = onChildRemoved(initialArray, child)
+          if (hasInitialLoad) {
+            obs.next(preserveSnapshot ? initialArray : initialArray.map(utils.unwrapMapFn));
+          }
+        }, err => {
+          if (err) { obs.error(err); obs.complete(); }
+        });
+        handles.push({ event: 'child_removed', handle: remFn });
+
+        let chgFn = ref.on('child_changed', (child: any, prevKey: string) => {
+          initialArray = onChildChanged(initialArray, child, prevKey)
+          if (hasInitialLoad) {
+            // This also manages when the only change is prevKey change
+            obs.next(preserveSnapshot ? initialArray : initialArray.map(utils.unwrapMapFn));
+          }
+        }, err => {
+          if (err) { obs.error(err); obs.complete(); }
+        });
+        handles.push({ event: 'child_changed', handle: chgFn });
+
+        // If empty emit the array
+        if (isInitiallyEmpty) {
+          obs.next(initialArray);
+          hasInitialLoad = true;
+        }
+      });
 
     return () => {
-      ref.off('child_added', addFn);
-      ref.off('child_removed', remFn);
-      ref.off('child_changed', chgFn);
-    }
+      // Loop through callback handles and dispose of each event with handle
+      // The Firebase SDK requires the reference, event name, and callback to
+      // properly unsubscribe, otherwise it can affect other subscriptions.
+      handles.forEach(item => {
+        ref.off(item.event, item.handle);
+      });
+    };
+
   });
 
   // TODO: should be in the subscription zone instead
   return observeOn.call(listObs, new utils.ZoneScheduler(Zone.current));
 }
 
-export function onChildAdded(arr:any[], child:any, prevKey:string): any[] {
+export function onChildAdded(arr: any[], child: any, prevKey: string): any[] {
   if (!arr.length) {
     return [child];
   }
 
-  return arr.reduce((accumulator:firebase.database.DataSnapshot[], curr:firebase.database.DataSnapshot, i:number) => {
-    if (!prevKey && i===0) {
+  return arr.reduce((accumulator: firebase.database.DataSnapshot[], curr: firebase.database.DataSnapshot, i: number) => {
+    if (!prevKey && i === 0) {
       accumulator.push(child);
     }
     accumulator.push(curr);
@@ -175,14 +217,14 @@ export function onChildAdded(arr:any[], child:any, prevKey:string): any[] {
   }, []);
 }
 
-export function onChildChanged(arr:any[], child:any, prevKey:string): any[] {
-  return arr.reduce((accumulator:any[], val:any, i:number) => {
-    if (!prevKey && i==0) {
+export function onChildChanged(arr: any[], child: any, prevKey: string): any[] {
+  return arr.reduce((accumulator: any[], val: any, i: number) => {
+    if (!prevKey && i == 0) {
       accumulator.push(child);
       if (val.key !== child.key) {
         accumulator.push(val);
       }
-    } else if(val.key === prevKey) {
+    } else if (val.key === prevKey) {
       accumulator.push(val);
       accumulator.push(child);
     } else if (val.key !== child.key) {
@@ -192,15 +234,15 @@ export function onChildChanged(arr:any[], child:any, prevKey:string): any[] {
   }, []);
 }
 
-export function onChildRemoved(arr:any[], child:any): any[] {
+export function onChildRemoved(arr: any[], child: any): any[] {
   return arr.filter(c => c.key !== child.key);
 }
 
-export function onChildUpdated(arr:any[], child:any, prevKey:string): any[] {
+export function onChildUpdated(arr: any[], child: any, prevKey: string): any[] {
   return arr.map((v, i, arr) => {
-    if(!prevKey && !i) {
+    if (!prevKey && !i) {
       return child;
-    } else if (i > 0 && arr[i-1].key === prevKey) {
+    } else if (i > 0 && arr[i - 1].key === prevKey) {
       return child;
     } else {
       return v;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import * as firebase from 'firebase';
 import { Subscription } from 'rxjs/Subscription';
 import { Scheduler } from 'rxjs/Scheduler';
 import { queue } from 'rxjs/scheduler/queue';
-import { AFUnwrappedDataSnapshot} from './interfaces';
+import { AFUnwrappedDataSnapshot } from './interfaces';
 
 export function isNil(obj: any): boolean {
   return obj === undefined || obj === null;


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #574 (required)
   - Docs included?: Lots of comments 
   - Test units included?: yes
   - e2e tests included?: n/a
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description
Fixes issue with FirebaseListFactory emitting items individually rather than the initial data set.

### Code sample

```ts
@Component({

})
class SampleComponent implements NgOnInit {
  constructor(private _af: AngularFire) {}
  ngOnInit() {
    this.af.list('items').subscribe(list => {
      // Full list!
      console.log(list);
    });
  }
}
```