### PR TITLE
fix(aot): Remove AuthBackend param for AOT support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularfire2",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7-pre",
   "description": "",
   "main": "bundles/angularfire2.umd.js",
   "module": "index.js",
@@ -28,7 +28,7 @@
     "type": "git",
     "url": "git+https://github.com/angular/angularfire2.git"
   },
-  "author": "jeffbcross",
+  "author": "jeffbcross,davideast",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/angular/angularfire2/issues"

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -62,7 +62,7 @@ export function _getWindowLocation(){
 }
 
 export function _getAuthBackend(app: firebase.app.App): FirebaseSdkAuthBackend {
-  return new FirebaseSdkAuthBackend(app, false);
+  return new FirebaseSdkAuthBackend(app);
 }
 
 export function _getDefaultFirebase(config){

--- a/src/auth/firebase_sdk_auth_backend.ts
+++ b/src/auth/firebase_sdk_auth_backend.ts
@@ -34,8 +34,7 @@ export class FirebaseSdkAuthBackend extends AuthBackend {
    * https://github.com/angular/angular/issues/12631
    * https://github.com/angular/angularfire2/issues/653
    **/
-  constructor( @Inject(FirebaseApp) _fbApp: any,
-    private _webWorkerMode = false) {
+  constructor(@Inject(FirebaseApp) _fbApp: any) {
     super();
     this._fbAuth = _fbApp.auth();
   }


### PR DESCRIPTION
### Checklist
   - Issue number for this PR: #728 
   - Docs included?: N/A
   - Test units included?: N/A
   - e2e tests included?: N/A
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description
Fix for #728. The solution was to remove the web worker parameter as we do not support web workers with auth at the moment.

Verified no errors when building locally with @StephenFluin's [aot-repo](https://github.com/StephenFluin/aot-repro).

cc: @hansl and @chuckjaz