### PR TITLE
chore(build): Set Firebase, Angular, and rxjs as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularfire2",
-  "version": "2.0.0-beta.7-pre",
+  "version": "2.0.0-beta.7.1-pre",
   "description": "",
   "main": "bundles/angularfire2.umd.js",
   "module": "index.js",
@@ -77,7 +77,7 @@
     "traceur": "0.0.96",
     "typedoc": "github:jeffbcross/typedoc",
     "typescript": "^2.0.2",
-    "zone.js": "^0.6.26"
+    "zone.js": "^0.7.2"
   },
   "typings": "index.d.ts"
 }

--- a/tools/rewrite-published-package.js
+++ b/tools/rewrite-published-package.js
@@ -10,6 +10,8 @@ delete srcPackage.scripts;
 
 var peerDependencies = Object.assign({}, srcPackage.dependencies);
 
+delete srcPackage.dependencies;
+
 var outPackage = Object.assign({}, srcPackage, { peerDependencies });
 
 fs.writeFileSync('./dist/package.json', JSON.stringify(outPackage, null, 2));


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #707, #747 
   - Docs included?: yes
   - Test units included?: N/A
   - e2e tests included?: N/A
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

In post build all dependencies (Firebase, Angular, rxjs) are set as `peerDeependencies` to avoid version mismatch errors.
