### PR TITLE
chore(api): Remove old database and auth providers

### DIFF
--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -26,7 +26,6 @@ import {
   FirebaseSdkAuthBackend,
   AngularFireAuth,
   firebaseAuthConfig,
-  FirebaseAuth,
   AuthBackend,
   AuthMethods,
   AuthProviders,
@@ -37,8 +36,7 @@ import {
   FirebaseObjectObservable,
   FirebaseListFactory,
   FirebaseObjectFactory,
-  AngularFireDatabase,
-  FirebaseDatabase
+  AngularFireDatabase
 } from './database/index';
 
 @Injectable()
@@ -77,10 +75,6 @@ export function _getDefaultFirebase(config){
 }
 
 export const COMMON_PROVIDERS: any[] = [
-  // TODO: Deprecate
-  { provide: FirebaseAuth,
-    useExisting: AngularFireAuth
-  },
   {
     provide: FirebaseApp,
     useFactory: _getFirebase,
@@ -135,10 +129,6 @@ export class AngularFireModule {
 export {
   AngularFireAuth,
   AngularFireDatabase,
-  // TODO: Deprecate
-  FirebaseAuth,
-  // TODO: Deprecate
-  FirebaseDatabase,
   FirebaseListObservable,
   FirebaseObjectObservable,
   FirebaseListFactory,

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -185,5 +185,3 @@ function attachCredentialToAuthState (authState: FirebaseAuthState, credential, 
   authState[stripProviderId(providerId)] = credential;
   return authState;
 }
-// TODO: Deprecate
-export class FirebaseAuth extends AngularFireAuth {}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -29,9 +29,6 @@ export class AngularFireDatabase {
   }
 }
 
-// TODO: Deprecate
-export class FirebaseDatabase extends AngularFireDatabase {}
-
 function getAbsUrl (root:FirebaseAppConfig, url:string) {
   if (!(/^[a-z]+:\/\/.*/.test(url))) {
     // Provided url is relative.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #754 (required)
   - Docs included?: N/A
   - Test units included?: N/A
   - e2e tests included?: N/A
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes
### Description

Awhile back we renamed `FirebaseAuth` to `AngularFireAuth` and `FirebaseDatabase` to `AngularFireDatabase`.

This does not affect most developers as they inject everything through the `AngularFire` service. However, you can inject them individually so we decided to keep the old names around for a bit by extending from the new classes.

Enough time has passed to push people to the new providers, and it's a small use case anyway.

However, if you see ERROR: FirebaseAuth not defined or ERROR: FirebaseDatabase not defined then switch to the new names: AngularFireAuth and AngularFireDatabase. 