### PR TITLE
chore(types): Add missing FirebaseAppConfig type

### DIFF
--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -68,7 +68,7 @@ export function _getAuthBackend(app: firebase.app.App): FirebaseSdkAuthBackend {
   return new FirebaseSdkAuthBackend(app);
 }
 
-export function _getDefaultFirebase(config){
+export function _getDefaultFirebase(config: FirebaseUserConfig): FirebaseUserConfig {
   // remove a trailing slash from the Database URL if it exists
   config.databaseURL = utils.stripTrailingSlash(config.databaseURL);
   return config;

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -68,7 +68,7 @@ export function _getAuthBackend(app: firebase.app.App): FirebaseSdkAuthBackend {
   return new FirebaseSdkAuthBackend(app);
 }
 
-export function _getDefaultFirebase(config: FirebaseUserConfig) {
+export function _getDefaultFirebase(config: FirebaseAppConfig) {
   // remove a trailing slash from the Database URL if it exists
   config.databaseURL = utils.stripTrailingSlash(config.databaseURL);
   return config;

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -68,7 +68,7 @@ export function _getAuthBackend(app: firebase.app.App): FirebaseSdkAuthBackend {
   return new FirebaseSdkAuthBackend(app);
 }
 
-export function _getDefaultFirebase(config: FirebaseUserConfig): FirebaseUserConfig {
+export function _getDefaultFirebase(config: FirebaseUserConfig) {
   // remove a trailing slash from the Database URL if it exists
   config.databaseURL = utils.stripTrailingSlash(config.databaseURL);
   return config;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #756  (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - e2e tests included?: (yes/no; required for multi-function/multi-class changes)
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? (yes/no; required)

### Description

Add missing type so the DI provider can get correctly during AoT (not tested yet)



**WIP**, will squash when tested
