### PR TITLE
Fixing a bug in child_added event handler

### DIFF
--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -563,6 +563,43 @@ describe('FirebaseListFactory', () => {
         ref.push('in-the-zone');
       });
     });
+
+    describe('Removing and replacing a child key', () => {
+      const firstKey = 'index1';
+      const middleKey = 'index2';
+      const lastKey = 'index3';
+      const initialData = {
+        [firstKey]: true,
+        [middleKey]: true,
+        [lastKey]: true,
+      };
+      let keyToRemove: string;
+
+      afterEach((done: any) => {
+        subscription = questions
+          .skip(2)
+          .take(1)
+          .subscribe((items: any[]) => {
+            expect(items.length).toBe(3);
+            done();
+          }, done.fail);
+        questions.$ref.ref.set(initialData)
+          .then(() => ref.child(keyToRemove).remove())
+          .then(() => ref.child(keyToRemove).set(true));
+      });
+
+      it('should work with the first item in the list', () => {
+        keyToRemove = firstKey;
+      });
+
+      it('should work with the middle item in the list', () => {
+        keyToRemove = middleKey;
+      });
+
+      it('should work with the last item in the list', () => {
+        keyToRemove = lastKey;
+      });
+    });
   });
 });
 

--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -134,7 +134,7 @@ function firebaseListObservable(ref: firebase.database.Reference | firebase.data
           // If the initial load has not been set and the current key is
           // the last key of the initialArray, we know we have hit the
           // initial load
-          if (!isInitiallyEmpty) {
+          if (!isInitiallyEmpty && !hasInitialLoad) {
             if (child.key === lastKey) {
               hasInitialLoad = true;
               obs.next(preserveSnapshot ? initialArray : initialArray.map(utils.unwrapMapFn));


### PR DESCRIPTION
To reproduce bug:

Create a `FirebaseListObservable` on an **existing** non-empty reference:
```
{
  index1: true,
  index2: true,
  index3: true
}
```
Remove the last child in the list. The `FirebaseListObservable` emits the correct list with the last item removed.

Then add the same item (i.e. using the same key) back to the list. Because `hasInitialLoad` is not checked in the `child_added` event handler, and because `child.key === lastKey`, the function returns prematurely and `onChildAdded` is not called. As a result the `FirebaseListObservable` emits an unchanged list, without appending the item as expected.

Sorry I haven't been able to create a unit test to demonstrate the bug. I hope the description is clear enough!