### PR TITLE
feat(database): adds auditTime for queries

### DIFF
--- a/src/database/query_observable.spec.ts
+++ b/src/database/query_observable.spec.ts
@@ -124,13 +124,15 @@ describe('observeQuery', () => {
 });
 
 
-// describe('getOrderObservables', () => {
-//   it('should be subscribable event if no observables found for orderby', () => {
-//     expect(() => {
-//       getOrderObservables((<Query>{})).subscribe();
-//     }).not.toThrow();
-//   });
-// });
+describe('getOrderObservables', () => {
+  it('should be subscribable event if no observables found for orderby', () => {
+    var nextSpy = jasmine.createSpy('next');
+    var obs = getOrderObservables({});
+    obs.subscribe(nextSpy);
+    expect(nextSpy).toHaveBeenCalledWith(null);
+  });
+});
+
 
 describe('query combinations', () => {
 

--- a/src/database/query_observable.spec.ts
+++ b/src/database/query_observable.spec.ts
@@ -92,7 +92,6 @@ describe('observeQuery', () => {
 
 
   it('should omit only the orderBy type of the last emitted orderBy observable', () => {
-    // TODO: Should we allow re-emitting of the orderBy method?
     var nextSpy = jasmine.createSpy('next');
     var query = {
       orderByKey: new Subject<boolean>(),
@@ -108,13 +107,19 @@ describe('observeQuery', () => {
     });
     nextSpy.calls.reset();
     query.orderByKey.next(true);
-    expect(nextSpy).not.toHaveBeenCalled();
-    // nextSpy.calls.reset();
-    // query.orderByValue.next(true);
-    // expect(nextSpy).toHaveBeenCalledWith({orderByValue: true});
-    // nextSpy.calls.reset();
+    expect(nextSpy).toHaveBeenCalledWith({
+      orderByKey: true
+    });
+    nextSpy.calls.reset();
+    query.orderByValue.next(true);
+    expect(nextSpy).toHaveBeenCalledWith({
+      orderByValue: true
+    });
+    nextSpy.calls.reset();
     query.orderByChild.next('foo');
-    expect(nextSpy).toHaveBeenCalledWith({orderByChild: 'foo'});
+    expect(nextSpy).toHaveBeenCalledWith({
+      orderByChild: 'foo'
+    });
   });
 });
 

--- a/src/database/query_observable.ts
+++ b/src/database/query_observable.ts
@@ -23,8 +23,8 @@ export function observeQuery(query: Query): Observable<ScalarQuery> {
 
   return Observable.create((observer: Observer<ScalarQuery>) => {
 
-    let obs = getOrderObservables(query) as Observable<OrderBySelection>;
-    combineLatest.call(obs,
+    combineLatest.call(
+        getOrderObservables(query),
         getStartAtObservable(query),
         getEndAtObservable(query),
         getEqualToObservable(query),
@@ -80,7 +80,7 @@ export function observeQuery(query: Query): Observable<ScalarQuery> {
   });
 }
 
-export function getOrderObservables(query: Query): Observable<OrderBySelection> | Observable<OrderBySelection | Observable<OrderBySelection>> {
+export function getOrderObservables(query: Query): Observable<OrderBySelection> {
   var observables = ['orderByChild', 'orderByKey', 'orderByValue', 'orderByPriority']
     .map((key: string, option: OrderByOptions) => {
       return ({ key, option })
@@ -93,7 +93,7 @@ export function getOrderObservables(query: Query): Observable<OrderBySelection> 
   if (observables.length === 1) {
     return observables[0];
   } else if (observables.length > 1) {
-    return merge.call(observables[0], observables.slice(1));
+    return merge.apply(observables[0], observables.slice(1));
   } else {
     return new Observable<OrderBySelection>(subscriber => {
       subscriber.next(null);
@@ -101,7 +101,7 @@ export function getOrderObservables(query: Query): Observable<OrderBySelection> 
   }
 }
 
-export function getLimitToObservables(query: Query): Observable<LimitToSelection> | Observable<LimitToSelection | Observable<LimitToSelection>> {
+export function getLimitToObservables(query: Query): Observable<LimitToSelection> {
   var observables = ['limitToFirst', 'limitToLast']
     .map((key: string, option: LimitToOptions) => ({ key, option }))
     .filter(({key, option}: { key: string, option: LimitToOptions }) => !isNil(query[key]))
@@ -110,7 +110,7 @@ export function getLimitToObservables(query: Query): Observable<LimitToSelection
   if (observables.length === 1) {
     return observables[0];
   } else if (observables.length > 1) {
-    const mergedObs = merge.call(observables[0], observables.slice(1));
+    const mergedObs = merge.apply(observables[0], observables.slice(1));
     return mergedObs;
   } else {
     return new Observable<LimitToSelection>(subscriber => {

--- a/src/test-root.ts
+++ b/src/test-root.ts
@@ -1,8 +1,8 @@
-export * from './angularfire2.spec';
-export * from './database/firebase_list_factory.spec';
-export * from './database/firebase_object_factory.spec';
-export * from './database/firebase_list_observable.spec';
-export * from './database/firebase_object_observable.spec';
-export * from './database/query_observable.spec';
-export * from './auth/auth.spec';
-export * from './auth/auth_backend.spec';
+import './angularfire2.spec';
+import './database/firebase_list_factory.spec';
+import './database/firebase_object_factory.spec';
+import './database/firebase_list_observable.spec';
+import './database/firebase_object_observable.spec';
+import './database/query_observable.spec';
+import './auth/auth.spec';
+import './auth/auth_backend.spec';


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #389 and #770
   - Docs included?: no 
   - Test units included?: yes 
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

This PR adds an [`auditTime(0)`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-auditTime) operator to the composed query observable. That means the query is not emitted immediately, but is emitted in the event loop - so if there are changes made to multiple subjects, those changes don't result in the emission of multiple queries. See [this comment](https://github.com/angular/angularfire2/issues/770#issuecomment-272402754).

I've made the auditing optional (it defaults to `true`) so that the `observeQuery` tests could remain synchronous and simple. The other tests now use auditing. And I've added some specific audit tests, too.

Also, this PR fixes a bug in which `call` was used instead of `apply` when composing the `merge` operator. Said operator takes a variable number of observables not an array, so `apply` should be used. (This also cleans up the calling function's result type - which was weird because the use of `call` sometimes saw observables emitted.)

The PR also changes `test-root.ts` to `import` rather than `export`, as I was unable to get Rollup to build a non-empty test bundle - even when using only the dependencies installed with AngularFire2.