### PR TITLE
FirebaseAuth didn't exist for me. It's AngularFireAuth

### DIFF
--- a/docs/Auth-with-Ionic2.md
+++ b/docs/Auth-with-Ionic2.md
@@ -262,13 +262,13 @@ Update the service with the following code.
 ```bash
 
 import { Injectable } from '@angular/core';
-import { AuthProviders, FirebaseAuth, FirebaseAuthState, AuthMethods } from 'angularfire2';
+import { AuthProviders, AngularFireAuth, FirebaseAuthState, AuthMethods } from 'angularfire2';
 
 @Injectable()
 export class AuthService {
   private authState: FirebaseAuthState;
 
-  constructor(public auth$: FirebaseAuth) {
+  constructor(public auth$: AngularFireAuth) {
     this.authState = auth$.getAuth();
     auth$.subscribe((state: FirebaseAuthState) => {
       this.authState = state;
@@ -470,7 +470,7 @@ your ```auth-service.ts``` code should look like this.
 
 
 import { Injectable } from '@angular/core';
-import { AuthProviders, FirebaseAuth, FirebaseAuthState, AuthMethods } from 'angularfire2';
+import { AuthProviders, AngularFireAuth, FirebaseAuthState, AuthMethods } from 'angularfire2';
 
 import { Platform } from 'ionic-angular';
 import { Facebook } from 'ionic-native';
@@ -479,7 +479,7 @@ import { Facebook } from 'ionic-native';
 export class AuthService {
   private authState: FirebaseAuthState;
 
-  constructor(public auth$: FirebaseAuth, private platform: Platform) {
+  constructor(public auth$: AngularFireAuth, private platform: Platform) {
     this.authState = auth$.getAuth();
     auth$.subscribe((state: FirebaseAuthState) => {
       this.authState = state;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required) *none* it's a docs change
   - Docs included?: (yes/no; required for all API/functional changes)  *it is docs*
   - Test units included?: (yes/no; required) *n/a*
   - e2e tests included?: (yes/no; required for multi-function/multi-class changes) *n/a*
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? (yes/no; required) *n/a*

### Description

FirebaseAuth didn't exist for the latest dependencies I could find. AngularFireAuth works though
    "angularfire2": "^2.0.0-beta.7",
    "firebase": "^3.6.6",
    "ionic-angular": "2.0.0-rc.5",
    "ionic-native": "2.2.11",
<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

