### PR TITLE
fix(utils): Make object $key and $exists properties non-enumerable

### DIFF
--- a/src/database/firebase_object_factory.spec.ts
+++ b/src/database/firebase_object_factory.spec.ts
@@ -81,12 +81,12 @@ describe('FirebaseObjectFactory', () => {
 
 
     it('should emit unwrapped data by default', (done: any) => {
-      ref.set({ data: 'bar' }, () => {
+      const fixtureData = { data: 'bar' };
+      ref.set(fixtureData, () => {
         subscription = observable.subscribe(unwrapped => {
           if (!unwrapped) return;
-          const expectedObject = { $key: ref.key, data: 'bar' };
-          expect(unwrapped.$key).toEqual(expectedObject.$key);
-          expect(unwrapped.data).toEqual(expectedObject.data);
+          expect(unwrapped.$key).toEqual(ref.key);
+          expect(unwrapped).toEqual(fixtureData);
           expect(unwrapped.$exists()).toEqual(true);
           done();
         });

--- a/src/database/firebase_object_observable.spec.ts
+++ b/src/database/firebase_object_observable.spec.ts
@@ -30,7 +30,7 @@ describe('FirebaseObjectObservable', () => {
     });
     inject([FirebaseApp, AngularFire], (firebaseApp: firebase.app.App, _af: AngularFire) => {
       app = firebaseApp;
-      ref = firebase.database().ref()
+      ref = firebase.database().ref();
       O = new FirebaseObjectObservable((observer:Observer<any>) => {
       }, ref);
     })();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,10 @@ export function unwrapMapFn (snapshot:firebase.database.DataSnapshot): AFUnwrapp
       $value: unwrapped
     };
   }
-  Object.defineProperty(unwrapped, '$key', {value: snapshot.ref.key, enumerable: false});
+  Object.defineProperty(unwrapped, '$key', {
+    value: snapshot.ref.key,
+    enumerable: false
+  });
   Object.defineProperty(unwrapped, '$exists', {
     value: () => {
       return snapshot.exists();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,10 +57,13 @@ export function unwrapMapFn (snapshot:firebase.database.DataSnapshot): AFUnwrapp
       $value: unwrapped
     };
   }
-  unwrapped.$key = snapshot.ref.key;
-  unwrapped.$exists = () => {
-    return snapshot.exists();
-  };
+  Object.defineProperty(unwrapped, '$key', {value: snapshot.ref.key, enumerable: false});
+  Object.defineProperty(unwrapped, '$exists', {
+    value: () => {
+      return snapshot.exists();
+    },
+    enumerable: false
+  });
   return unwrapped;
 }
 


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #302
   - Docs included?: no
   - Test units included?: yes
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

Exact same pull request as #535, addresses rebase merge conflicts. All credit for original fix goes to @meDavid.