### PR TITLE
docs: Add FIREBASE_PROVIDERS to the install and setup document.

### DIFF
--- a/docs/1-install-and-setup.md
+++ b/docs/1-install-and-setup.md
@@ -63,7 +63,7 @@ This can be found in your project at [the Firebase Console](https://console.fire
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { AppComponent } from './app.component';
-import { AngularFireModule } from 'angularfire2';
+import { FIREBASE_PROVIDERS, AngularFireModule } from 'angularfire2';
 
 // Must export the config
 export const firebaseConfig = {
@@ -80,6 +80,7 @@ export const firebaseConfig = {
     AngularFireModule.initializeApp(firebaseConfig)
   ],
   declarations: [ AppComponent ],
+  providers: [FIREBASE_PROVIDERS],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {}
@@ -96,6 +97,7 @@ You can optionally provide a custom FirebaseApp name with `initializeApp`.
     AngularFireModule.initializeApp(firebaseConfig, authConfig, 'my-app-name')
   ],
   declarations: [ AppComponent ],
+  providers: [FIREBASE_PROVIDERS],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {}


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #789
   - Docs included?: yes
   - Test units included?: no
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

I included angularfire2 in an example I was working on, following the install and setup document I got an error saying "No provider for AngularFire!". I fixed it including the providers in the app.module.ts. I updated the documentation to reflect this change. 

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

