### PR TITLE
fix(database): allow null values for equalTo, etc.

### DIFF
--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -477,6 +477,63 @@ describe('FirebaseListFactory', () => {
     });
 
 
+    it('should support null for equalTo queries', (done: any) => {
+
+      questions.$ref.ref.set({
+        val1,
+        val2: Object.assign({}, val2, { extra: true }),
+        val3: Object.assign({}, val3, { extra: true }),
+      })
+      .then(() => {
+
+        var query = FirebaseListFactory(questions.$ref.ref, {
+          query: {
+            orderByChild: "extra",
+            equalTo: null
+          }
+        });
+
+        take.call(query, 1).subscribe(
+          (list) => {
+            expect(list.length).toEqual(1);
+            expect(list[0].$key).toEqual("val1");
+            done();
+          },
+          done.fail
+        );
+      });
+    });
+
+
+    it('should support null for startAt/endAt queries', (done: any) => {
+
+      questions.$ref.ref.set({
+        val1,
+        val2: Object.assign({}, val2, { extra: true }),
+        val3: Object.assign({}, val3, { extra: true }),
+      })
+      .then(() => {
+
+        var query = FirebaseListFactory(questions.$ref.ref, {
+          query: {
+            orderByChild: "extra",
+            startAt: null,
+            endAt: null
+          }
+        });
+
+        take.call(query, 1).subscribe(
+          (list) => {
+            expect(list.length).toEqual(1);
+            expect(list[0].$key).toEqual("val1");
+            done();
+          },
+          done.fail
+        );
+      });
+    });
+
+
     it('should call off on all events when disposed', (done: any) => {
       const questionRef = firebase.database().ref().child('questions');
       var firebaseSpy = spyOn(questionRef, 'off').and.callThrough();

--- a/src/database/query_observable.spec.ts
+++ b/src/database/query_observable.spec.ts
@@ -422,3 +422,52 @@ describe('query combinations', () => {
     });
 
 });
+
+describe('null values', () => {
+
+  it('should build an equalTo() query with a null scalar value', (done: any) => {
+    scalarQueryTest({
+      orderByChild: 'height',
+      equalTo: null
+    }, done);
+  });
+
+  it('should build a startAt() query with a null scalar value', (done: any) => {
+    scalarQueryTest({
+      orderByChild: 'height',
+      startAt: null
+    }, done);
+  });
+
+  it('should build an endAt() query with a null scalar value', (done: any) => {
+    scalarQueryTest({
+      orderByChild: 'height',
+      endAt: null
+    }, done);
+  });
+
+  it('should build an equalTo() query with a null observable value', (done: any) => {
+    const query = {
+      orderByChild: 'height',
+      equalTo: new Subject()
+    };
+    observableQueryTest(query, { equalTo: null }, done);
+  });
+
+  it('should build a startAt() query with a null observable value', (done: any) => {
+    const query = {
+      orderByChild: 'height',
+      startAt: new Subject()
+    };
+    observableQueryTest(query, { startAt: null }, done);
+  });
+
+  it('should build an endAt() query with a null observable value', (done: any) => {
+    const query = {
+      orderByChild: 'height',
+      endAt: new Subject()
+    };
+    observableQueryTest(query, { endAt: null }, done);
+  });
+
+});

--- a/src/database/query_observable.ts
+++ b/src/database/query_observable.ts
@@ -14,7 +14,7 @@ import {
   LimitToSelection,
   Primitive
 } from '../interfaces';
-import { isNil } from '../utils';
+import { hasKey, isNil } from '../utils';
 
 export function observeQuery(query: Query): Observable<ScalarQuery> {
   if (isNil(query)) {
@@ -63,15 +63,15 @@ export function observeQuery(query: Query): Observable<ScalarQuery> {
           }
         }
 
-        if (!isNil(startAt)) {
+        if (startAt !== undefined) {
           serializedOrder.startAt = startAt;
         }
 
-        if (!isNil(endAt)) {
+        if (endAt !== undefined) {
           serializedOrder.endAt = endAt;
         }
 
-        if (!isNil(equalTo)) {
+        if (equalTo !== undefined) {
           serializedOrder.equalTo = equalTo;
         }
 
@@ -122,13 +122,13 @@ export function getLimitToObservables(query: Query): Observable<LimitToSelection
 export function getStartAtObservable(query: Query): Observable<Primitive> {
   if (query.startAt instanceof Observable) {
     return query.startAt;
-  } else if (typeof query.startAt !== 'undefined') {
+  } else if (hasKey(query, 'startAt')) {
     return new Observable<Primitive>(subscriber => {
       subscriber.next(query.startAt);
     });
   } else {
     return new Observable<Primitive>(subscriber => {
-      subscriber.next(null);
+      subscriber.next(undefined);
     });
   }
 }
@@ -136,13 +136,13 @@ export function getStartAtObservable(query: Query): Observable<Primitive> {
 export function getEndAtObservable(query: Query): Observable<Primitive> {
   if (query.endAt instanceof Observable) {
     return query.endAt;
-  } else if (typeof query.endAt !== 'undefined') {
+  } else if (hasKey(query, 'endAt')) {
     return new Observable<Primitive>(subscriber => {
       subscriber.next(query.endAt);
     });
   } else {
     return new Observable<Primitive>(subscriber => {
-      subscriber.next(null);
+      subscriber.next(undefined);
     });
   }
 }
@@ -150,13 +150,13 @@ export function getEndAtObservable(query: Query): Observable<Primitive> {
 export function getEqualToObservable(query: Query): Observable<Primitive> {
   if (query.equalTo instanceof Observable) {
     return query.equalTo;
-  } else if (typeof query.equalTo !== 'undefined') {
+  } else if (hasKey(query, 'equalTo')) {
     return new Observable<Primitive>(subscriber => {
       subscriber.next(query.equalTo);
     });
   } else {
     return new Observable<Primitive>(subscriber => {
-      subscriber.next(null);
+      subscriber.next(undefined);
     });
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #704 and #715
   - Docs included?: no
   - Test units included?: yes
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

The previous PR for #704 did not include tests and did not completely fix the issue, as `null` values were swallowed with the query observable. This PR addresses that and includes tests.

Also, this PR ensures that the query observable emits `undefined` if values are not specified for `equalTo`, `startAt` or `endAt` - as `null` has a specific meaning.