### PR TITLE
fix(database): retrieve initial list content once

### DIFF
--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -108,88 +108,71 @@ export function FirebaseListFactory (
  * is loaded, the observable starts emitting values.
  */
 function firebaseListObservable(ref: firebase.database.Reference | firebase.database.Query, {preserveSnapshot}: FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
+
   const toValue = preserveSnapshot ? (snapshot => snapshot) : utils.unwrapMapFn;
   const toKey = preserveSnapshot ? (value => value.key) : (value => value.$key);
-  // Keep track of callback handles for calling ref.off(event, handle)
-  const handles = [];
+
   const listObs = new FirebaseListObservable(ref, (obs: Observer<any[]>) => {
-    ref.once('value')
-      .then((snap) => {
-        let initialArray = [];
-        snap.forEach(child => {
-          initialArray.push(toValue(child))
-        });
-        return initialArray;
-      })
-      .then((initialArray) => {
-        const isInitiallyEmpty = initialArray.length === 0;
-        let hasInitialLoad = false;
-        let lastKey;
 
-        if (!isInitiallyEmpty) {
-          // The last key in the initial array tells us where
-          // to begin listening in realtime
-          lastKey = toKey(initialArray[initialArray.length - 1]);
+    // Keep track of callback handles for calling ref.off(event, handle)
+    const handles = [];
+    let hasLoaded = false;
+    let lastLoadedKey: string = null;
+    let array = [];
+
+    // The list children are always added to, removed from and changed within
+    // the array using the child_added/removed/changed events. The value event
+    // is only used to determine when the initial load is complete.
+
+    ref.once('value', (snap: any) => {
+      if (snap.exists()) {
+        snap.forEach((child: any) => {
+          lastLoadedKey = child.key;
+        });
+        if (array.find((child: any) => toKey(child) === lastLoadedKey)) {
+          hasLoaded = true;
+          obs.next(array);
         }
+      } else {
+        hasLoaded = true;
+        obs.next(array);
+      }
+    }, err => {
+      if (err) { obs.error(err); obs.complete(); }
+    });
 
-        const addFn = ref.on('child_added', (child: any, prevKey: string) => {
-          // If the initial load has not been set and the current key is
-          // the last key of the initialArray, we know we have hit the
-          // initial load
-          if (!isInitiallyEmpty && !hasInitialLoad) {
-            if (child.key === lastKey) {
-              hasInitialLoad = true;
-              obs.next(initialArray);
-              return;
-            }
-          }
+    const addFn = ref.on('child_added', (child: any, prevKey: string) => {
+      array = onChildAdded(array, toValue(child), toKey, prevKey);
+      if (hasLoaded) {
+        obs.next(array);
+      } else if (child.key === lastLoadedKey) {
+        hasLoaded = true;
+        obs.next(array);
+      }
+    }, err => {
+      if (err) { obs.error(err); obs.complete(); }
+    });
+    handles.push({ event: 'child_added', handle: addFn });
 
-          if (hasInitialLoad) {
-            initialArray = onChildAdded(initialArray, toValue(child), toKey, prevKey);
-          }
+    let remFn = ref.on('child_removed', (child: any) => {
+      array = onChildRemoved(array, toValue(child), toKey);
+      if (hasLoaded) {
+        obs.next(array);
+      }
+    }, err => {
+      if (err) { obs.error(err); obs.complete(); }
+    });
+    handles.push({ event: 'child_removed', handle: remFn });
 
-          // only emit the array after the initial load
-          if (hasInitialLoad) {
-            obs.next(initialArray);
-          }
-        }, err => {
-          if (err) { obs.error(err); obs.complete(); }
-        });
-
-        handles.push({ event: 'child_added', handle: addFn });
-
-        let remFn = ref.on('child_removed', (child: any) => {
-          initialArray = onChildRemoved(initialArray, toValue(child), toKey);
-          if (hasInitialLoad) {
-            obs.next(initialArray);
-          }
-        }, err => {
-          if (err) { obs.error(err); obs.complete(); }
-        });
-        handles.push({ event: 'child_removed', handle: remFn });
-
-        let chgFn = ref.on('child_changed', (child: any, prevKey: string) => {
-          initialArray = onChildChanged(initialArray, toValue(child), toKey, prevKey)
-          if (hasInitialLoad) {
-            // This also manages when the only change is prevKey change
-            obs.next(initialArray);
-          }
-        }, err => {
-          if (err) { obs.error(err); obs.complete(); }
-        });
-        handles.push({ event: 'child_changed', handle: chgFn });
-
-        // If empty emit the array
-        if (isInitiallyEmpty) {
-          obs.next(initialArray);
-          hasInitialLoad = true;
-        }
-      }, err => {
-        if (err) { 
-          obs.error(err); 
-          obs.complete(); 
-        }
-      });
+    let chgFn = ref.on('child_changed', (child: any, prevKey: string) => {
+      array = onChildChanged(array, toValue(child), toKey, prevKey);
+      if (hasLoaded) {
+        obs.next(array);
+      }
+    }, err => {
+      if (err) { obs.error(err); obs.complete(); }
+    });
+    handles.push({ event: 'child_changed', handle: chgFn });
 
     return () => {
       // Loop through callback handles and dispose of each event with handle


### PR DESCRIPTION
Closes #819

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #819
   - Docs included?: no 
   - Test units included?: no 
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

This PR simplifies the list implementation so that only the reducers associated with the `child_added/remove/changed` events manipulate the list's internal array. The `value` event is only used to determine when the initial load has been done.

The `on('value')` and `on('child_added', ...)` calls are made within the same turn through the event loop, so only a single copy of the initial content is retrieved.

The comments made in the commit that introduced this retrieve-the-initial-content-twice behaviour mention SDK quirks and nuances. By using only the `child_XXX` events and by not worrying whether the `child_added` event adds the last key before or after the `value` event fires, this PR's implementation should be sufficiently robust to cope with said quirks and nuances.