### PR TITLE
feat(database): support the optional startAt key

### DIFF
--- a/docs/4-querying-lists.md
+++ b/docs/4-querying-lists.md
@@ -28,8 +28,10 @@ const queryObservable = af.database.list('/items', {
 | `equalTo` | Limit list to items that contain certain value. |
 | `limitToFirst` | Sets the maximum number of items to return from the beginning of the ordered list of results. |
 | `limitToLast` | Sets the maximum number of items to return from the end of the ordered list of results. |
-| `startAt` | Return items greater than or equal to the specified key or value, depending on the order-by method chosen. |
+| `startAt` <sup>1</sup> | Return items greater than or equal to the specified key or value, depending on the order-by method chosen. |
 | `endAt` | Return items less than or equal to the specified key or value, depending on the order-by method chosen. |
+
+<sup>1</sup> The Firebase SDK supports [an optional `key` parameter](https://firebase.google.com/docs/reference/js/firebase.database.Reference#startAt) when ordering by child, value, or priority. You can specify the `key` parameter using `startAt: { value: 'some-value', key: 'some-key' }`
 
 ## Invalid query combinations
 

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -392,15 +392,15 @@ describe('FirebaseListFactory', () => {
 
 
     it('should emit a new value when a child moves', (done: any) => {
-       let question = skipAndTake(questions, 1, 2)
-       subscription = _do.call(question, (data: any) => {
-          expect(data.length).toBe(2);
-          expect(data[0].push2).toBe(true);
-          expect(data[1].push1).toBe(true);
-        })
-        .subscribe(() => {
-          done();
-        }, done.fail);
+     let question = skipAndTake(questions, 1, 2)
+     subscription = _do.call(question, (data: any) => {
+        expect(data.length).toBe(2);
+        expect(data[0].push2).toBe(true);
+        expect(data[1].push1).toBe(true);
+      })
+      .subscribe(() => {
+        done();
+      }, done.fail);
 
       var child1 = ref.push({ push1: true }, () => {
         ref.push({ push2: true }, () => {
@@ -634,6 +634,46 @@ describe('FirebaseListFactory', () => {
       it('should work with the last item in the list', () => {
         keyToRemove = lastKey;
       });
+    });
+
+    describe('startAt(value, key)', () => {
+
+      it('should support the optional key parameter to startAt', (done) => {
+
+        questions.$ref.ref.set({
+          val1: Object.assign({}, val1, { data: 0 }),
+          val2: Object.assign({}, val2, { data: 0 }),
+          val3: Object.assign({}, val3, { data: 0 })
+        })
+        .then(() => {
+
+          let query1 = FirebaseListFactory(`${rootDatabaseUrl}/questions`, {
+            query: {
+              orderByChild: 'data',
+              startAt: { value: 0 }
+            }
+          });
+          query1 = take.call(query1, 1);
+          query1 = toPromise.call(query1);
+
+          let query2 = FirebaseListFactory(`${rootDatabaseUrl}/questions`, {
+            query: {
+              orderByChild: 'data',
+              startAt: { value: 0, key: 'val2' }
+            }
+          });
+          query2 = take.call(query2, 1);
+          query2 = toPromise.call(query2);
+
+          Promise.all([query1, query2]).then(([list1, list2]) => {
+            expect(list1.map(i => i.$key)).toEqual(['val1', 'val2', 'val3']);
+            expect(list2.map(i => i.$key)).toEqual(['val2', 'val3']);
+            done();
+          });
+        })
+        .catch(done.fail);
+      });
+
     });
   });
 });

--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -70,7 +70,11 @@ export function FirebaseListFactory (
 
       // check startAt
       if (utils.hasKey(query, "startAt")) {
+        if (utils.hasKey(query.startAt, "value")) {
+          queried = queried.startAt(query.startAt.value, query.startAt.key);
+        } else {
           queried = queried.startAt(query.startAt);
+        }
       }
 
       if (utils.hasKey(query, "endAt")) {
@@ -185,9 +189,9 @@ function firebaseListObservable(ref: firebase.database.Reference | firebase.data
           hasInitialLoad = true;
         }
       }, err => {
-        if (err) { 
-          obs.error(err); 
-          obs.complete(); 
+        if (err) {
+          obs.error(err);
+          obs.complete();
         }
       });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #362
   - Docs included?: yes
   - Test units included?: yes
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

This PR introduces support for the optional `key` parameter that can be passed to the SDK's `startAt` method. According to the SDK documentation, the parameter is [*"allowed if ordering by child, value, or priority"*](https://firebase.google.com/docs/reference/js/firebase.database.Reference#startAt).

There was some discussion in the linked (and closed) issue regarding the `key` parameter only being supported and useful when ordering by priority, but the documentation suggests that it is also supported - by `startAt` - when ordering by child and value. Indeed, were it not to be supported, it would not be possible to reliably page through lists that are ordered by child when there are large numbers of items with the same child value. This is an issue that I currently have with an implementation of a `FirebaseListObservable`-based infinite list.

There is a plunk [here](https://plnkr.co/edit/ZF3lCGsTbLnnQCoenFIF) that demonstrates the use of `key` with the SDK to page when ordering by child.

### Code sample

The `key` parameter is really only useful when paging through results, so this code sample is contrived and not particularly sensible:

    let list = angularFire.database.list('some/data', {
      query: {
        orderByChild: 'some-child',
        startAt: { value: 'some-value', key: 'some-key' },
        limitToFirst: 10
      }
    });