### PR TITLE
chore(imports): Use naked imports for features

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@angular/core": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
-    "firebase": "^3.0.0",
+    "firebase": "^3.6.6",
     "rxjs": "^5.0.1"
   },
   "devDependencies": {

--- a/src/angularfire2.spec.ts
+++ b/src/angularfire2.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import {
   TestBed,
   inject

--- a/src/angularfire2.ts
+++ b/src/angularfire2.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import * as utils from './utils';
 import { FirebaseAppConfig } from './interfaces';
 import { AuthConfiguration } from './auth';
@@ -142,3 +142,4 @@ export {
 
 export { FirebaseConfig, FirebaseApp, FirebaseAuthConfig, FirebaseRef, FirebaseUrl, FirebaseUserConfig } from './tokens';
 export { FirebaseAppConfig } from './interfaces';
+

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { auth, initializeApp } from 'firebase';
 import { ReflectiveInjector, Provider } from '@angular/core';
 import { Observable } from 'rxjs/Observable'

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/auth';
 import { Provider, Inject, Injectable, Optional } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';

--- a/src/auth/auth_backend.spec.ts
+++ b/src/auth/auth_backend.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import {
   authDataToAuthState,
   AuthProviders,

--- a/src/auth/auth_backend.ts
+++ b/src/auth/auth_backend.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { Observable } from 'rxjs/Observable';
 
 export abstract class AuthBackend {

--- a/src/auth/firebase_sdk_auth_backend.ts
+++ b/src/auth/firebase_sdk_auth_backend.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { Injectable, Inject } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/database';
 import { Inject, Injectable } from '@angular/core';
 import { FirebaseApp, FirebaseConfig } from '../tokens';
 import { FirebaseAppConfig } from '../angularfire2';

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import {
   FirebaseListFactory,
   FirebaseListObservable,

--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/database';
 import { AFUnwrappedDataSnapshot } from '../interfaces';
 import { FirebaseListObservable } from './firebase_list_observable';
 import { Observer } from 'rxjs/Observer';

--- a/src/database/firebase_list_observable.spec.ts
+++ b/src/database/firebase_list_observable.spec.ts
@@ -1,7 +1,7 @@
 import { FirebaseListObservable } from './index';
 import { Observer } from 'rxjs/Observer';
 import { map } from 'rxjs/operator/map';
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { unwrapMapFn } from '../utils';
 import {
   FIREBASE_PROVIDERS,

--- a/src/database/firebase_list_observable.ts
+++ b/src/database/firebase_list_observable.ts
@@ -2,7 +2,8 @@ import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/database';
 import * as utils from '../utils';
 import {
   AFUnwrappedDataSnapshot,

--- a/src/database/firebase_object_factory.spec.ts
+++ b/src/database/firebase_object_factory.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { Subscription } from 'rxjs';
 import { FirebaseObjectFactory, FirebaseObjectObservable } from './index';
 import {

--- a/src/database/firebase_object_factory.ts
+++ b/src/database/firebase_object_factory.ts
@@ -1,7 +1,8 @@
 import { FirebaseObjectObservable } from './index';
 import { Observer } from 'rxjs/Observer';
 import { observeOn } from 'rxjs/operator/observeOn';
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/database';
 import * as utils from '../utils';
 import { FirebaseObjectFactoryOpts } from '../interfaces';
 

--- a/src/database/firebase_object_observable.spec.ts
+++ b/src/database/firebase_object_observable.spec.ts
@@ -14,7 +14,7 @@ import { COMMON_CONFIG, ANON_AUTH_CONFIG } from '../test-config';
 import { FirebaseObjectObservable } from './index';
 import { Observer } from 'rxjs/Observer';
 import { map } from 'rxjs/operator/map';
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 
 const rootDatabaseUrl = COMMON_CONFIG.databaseURL;
 

--- a/src/database/firebase_object_observable.ts
+++ b/src/database/firebase_object_observable.ts
@@ -2,7 +2,8 @@ import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
+import 'firebase/database';
 
 export class FirebaseObjectObservable<T> extends Observable<T> {
   constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, public $ref?:firebase.database.Reference) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { Observable } from 'rxjs/Observable';
 
 export interface FirebaseAppConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 import { Subscription } from 'rxjs/Subscription';
 import { Scheduler } from 'rxjs/Scheduler';
 import { queue } from 'rxjs/scheduler/queue';

--- a/src/worker/auth/worker/auth.ts
+++ b/src/worker/auth/worker/auth.ts
@@ -23,7 +23,7 @@ import {
   OAuthCredentials
 } from '../../auth_backend';
 import {isNil} from '../../../utils';
-import * as firebase from 'firebase';
+import * as firebase from 'firebase/app';
 
 @Injectable()
 export class WebWorkerFirebaseAuth extends AuthBackend {


### PR DESCRIPTION
### Checklist
   - Issue number for this PR: #851 (required)
   - Docs included?: N/A
   - Test units included?: N/A
   - e2e tests included?: N/A
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description
The Firebase SDK allows you to "naked import" a feature so module bundlers can import only what they need in the build.

To start, we should switch all features to use these imports. A following PR needs to break out each feature into an @NgModule.
