### PR TITLE
fix(database): Fix test TypeScript errors

### DIFF
--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -759,8 +759,7 @@ describe('FirebaseListFactory', () => {
               startAt: { value: 0 }
             }
           });
-          query1 = take.call(query1, 1);
-          query1 = toPromise.call(query1);
+          let promise1 = toPromise.call(take.call(query1, 1));
 
           let query2 = FirebaseListFactory(`questions`, {
             query: {
@@ -768,10 +767,9 @@ describe('FirebaseListFactory', () => {
               startAt: { value: 0, key: 'val2' }
             }
           });
-          query2 = take.call(query2, 1);
-          query2 = toPromise.call(query2);
+          let promise2 = toPromise.call(take.call(query2, 1));
 
-          Promise.all([query1, query2]).then(([list1, list2]) => {
+          Promise.all([promise1, promise2]).then(([list1, list2]) => {
             expect(list1.map(i => i.$key)).toEqual(['val1', 'val2', 'val3']);
             expect(list2.map(i => i.$key)).toEqual(['val2', 'val3']);
             done();
@@ -799,8 +797,7 @@ describe('FirebaseListFactory', () => {
               equalTo: { value: 0 }
             }
           });
-          query1 = take.call(query1, 1);
-          query1 = toPromise.call(query1);
+          let promise1 = toPromise.call(take.call(query1, 1));
 
           let query2 = FirebaseListFactory(`questions`, {
             query: {
@@ -808,10 +805,9 @@ describe('FirebaseListFactory', () => {
               equalTo: { value: 0, key: 'val2' }
             }
           });
-          query2 = take.call(query2, 1);
-          query2 = toPromise.call(query2);
+          let promise2 = toPromise.call(take.call(query2, 1));
 
-          Promise.all([query1, query2]).then(([list1, list2]) => {
+          Promise.all([promise1, promise2]).then(([list1, list2]) => {
             expect(list1.map(i => i.$key)).toEqual(['val1', 'val2', 'val3']);
             expect(list2.map(i => i.$key)).toEqual(['val2']);
             done();
@@ -839,8 +835,7 @@ describe('FirebaseListFactory', () => {
               endAt: { value: 0 }
             }
           });
-          query1 = take.call(query1, 1);
-          query1 = toPromise.call(query1);
+          let promise1 = toPromise.call(take.call(query1, 1));
 
           let query2 = FirebaseListFactory(`questions`, {
             query: {
@@ -848,10 +843,9 @@ describe('FirebaseListFactory', () => {
               endAt: { value: 0, key: 'val2' }
             }
           });
-          query2 = take.call(query2, 1);
-          query2 = toPromise.call(query2);
+          let promise2 = toPromise.call(take.call(query2, 1));
 
-          Promise.all([query1, query2]).then(([list1, list2]) => {
+          Promise.all([promise1, promise2]).then(([list1, list2]) => {
             expect(list1.map(i => i.$key)).toEqual(['val1', 'val2', 'val3']);
             expect(list2.map(i => i.$key)).toEqual(['val1', 'val2']);
             done();

--- a/src/database/query_observable.spec.ts
+++ b/src/database/query_observable.spec.ts
@@ -1,10 +1,10 @@
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 import { Subject } from 'rxjs/Subject';
-import { Query } from '../interfaces';
+import { Query, ScalarQuery } from '../interfaces';
 import { getOrderObservables, observeQuery } from './index';
 
-function scalarQueryTest(query: Query, done: any) {
+function scalarQueryTest(query: ScalarQuery, done: any) {
   const queryObservable = observeQuery(query);
   queryObservable.subscribe(result => {
     expect(result).toEqual(query);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #875
   - Docs included?: no 
   - Test units included?: no
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

This PR fixes TypeScript errors that are effected by `@types/jasmine` versions 2.5.46 and later - the declarations of which have replaced many uses of `any` with specific types.