### PR TITLE
fix(build): Add package.json files for deep paths

### DIFF
--- a/src/app/package.json
+++ b/src/app/package.json
@@ -1,0 +1,1 @@
+{ "main": "../bundles/angularfire2.umd.js" }

--- a/src/auth/package.json
+++ b/src/auth/package.json
@@ -1,0 +1,1 @@
+{ "main": "../bundles/angularfire2.umd.js" }

--- a/src/database/package.json
+++ b/src/database/package.json
@@ -1,0 +1,1 @@
+{ "main": "../bundles/angularfire2.umd.js" }

--- a/tools/rewrite-published-package.js
+++ b/tools/rewrite-published-package.js
@@ -15,3 +15,10 @@ delete srcPackage.dependencies;
 var outPackage = Object.assign({}, srcPackage, { peerDependencies });
 
 fs.writeFileSync('./dist/package.json', JSON.stringify(outPackage, null, 2));
+
+// It's also necessary to copy any deep-path package.json files.
+// See https://github.com/angular/angularfire2/issues/880
+
+['app', 'auth', 'database'].forEach(dir => {
+  fs.writeFileSync(`./dist/${dir}/package.json`, fs.readFileSync(`./src/${dir}/package.json`));
+});


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #880
   - Docs included?: no
   - Test units included?: no
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

This PR adds `package.json` files so that deep path imports will direct bundlers that do not recognise the `module` entry point to the UMD bundle.

This is the same approach taken with the Angular packages. There is more information in the referenced issue.

The PR also extends the `tools/rewrite-published-package.js` build script so that the `package.json` files are copied to the `dist` directory.