### PR TITLE
Remove extra `####` from docs

### DIFF
--- a/docs/Auth-with-Ionic2.md
+++ b/docs/Auth-with-Ionic2.md
@@ -243,7 +243,7 @@ C:\projects\Ionic_AngularFire2_Project> ionic serve
 
 ```
 
-####_This should fetch the data from firebase._
+This should fetch the data from firebase.
 
 ## Configuring AngularFire2 Auth with Ionic2
 


### PR DESCRIPTION
Looks like there was an extra (accidental?) Markdown H4 alongside italics on line 246. Updated to reflect the way the rest of the doc is formatted with "this should" statements.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - e2e tests included?: (yes/no; required for multi-function/multi-class changes)
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

