### PR TITLE
chore(refactor): Removed factory path params

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -15,7 +15,7 @@ export class AngularFireAuth {
    * Firebase Auth instance
    */
   auth: firebase.auth.Auth;
-  
+
   /**
    * Observable of authentication state
    */
@@ -35,7 +35,7 @@ export class AngularFireAuth {
  */
 export function FirebaseAuthStateObservable(app: FirebaseApp): Observable<firebase.User> {
   const authState = Observable.create((observer: Observer<firebase.User>) => {
-    firebase.auth().onAuthStateChanged(
+    app.auth().onAuthStateChanged(
       (user?: firebase.User) => observer.next(user),
       (error: firebase.auth.Error) => observer.error(error),
       () => observer.complete()

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -16,14 +16,12 @@ export class AngularFireDatabase {
 
   list(pathOrRef: PathReference, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
     const ref = utils.getRef(this.app, pathOrRef);
-    return FirebaseListFactory(utils.getRef(this.app, ref), opts);
+    return FirebaseListFactory(ref, opts);
   }
 
   object(pathOrRef: PathReference, opts?:FirebaseObjectFactoryOpts):FirebaseObjectObservable<any> {
-    return utils.checkForUrlOrFirebaseRef(pathOrRef, {
-      isUrl: () => FirebaseObjectFactory(this.app.database().ref(<string>pathOrRef), opts),
-      isRef: () => FirebaseObjectFactory(pathOrRef)
-    });
+    const ref = utils.getRef(this.app, pathOrRef);
+    return FirebaseObjectFactory(ref, opts);
   }
 
 }

--- a/src/database/firebase_list_factory.spec.ts
+++ b/src/database/firebase_list_factory.spec.ts
@@ -88,19 +88,8 @@ describe('FirebaseListFactory', () => {
 
   describe('<constructor>', () => {
 
-    it('should accept a Firebase db path in the constructor', () => {
-      const list = FirebaseListFactory(`questions`);
-      expect(list instanceof FirebaseListObservable).toBe(true);
-    });
-
     it('should accept a Firebase db ref in the constructor', () => {
-      const list = FirebaseListFactory(firebase.database().ref(`questions`));
-      expect(list instanceof FirebaseListObservable).toBe(true);
-    });
-
-    it('should take an absolute url in the constructor', () => {
-      const absoluteUrl = COMMON_CONFIG.databaseURL + '/questions';
-      const list = FirebaseListFactory(absoluteUrl);
+      const list = FirebaseListFactory(app.database().ref(`questions`));
       expect(list instanceof FirebaseListObservable).toBe(true);
     });
 
@@ -120,7 +109,7 @@ describe('FirebaseListFactory', () => {
       it('equalTo - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             equalTo: subject
@@ -133,7 +122,7 @@ describe('FirebaseListFactory', () => {
       it('startAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             startAt: subject
@@ -146,7 +135,7 @@ describe('FirebaseListFactory', () => {
       it('endAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             endAt: subject
@@ -158,7 +147,7 @@ describe('FirebaseListFactory', () => {
 
       it('should throw an error if limitToLast and limitToFirst are chained', () => {
 
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             limitToFirst: 10,
@@ -170,7 +159,7 @@ describe('FirebaseListFactory', () => {
 
       it('should throw an error if startAt is used with equalTo', () => {
 
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             equalTo: 10,
@@ -182,7 +171,7 @@ describe('FirebaseListFactory', () => {
 
       it('should throw an error if endAt is used with equalTo', () => {
 
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             equalTo: 10,
@@ -194,7 +183,7 @@ describe('FirebaseListFactory', () => {
 
       it('should throw an error if startAt and endAt is used with equalTo', () => {
 
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             equalTo: 10,
@@ -219,7 +208,7 @@ describe('FirebaseListFactory', () => {
       it('equalTo - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByValue: true,
             equalTo: subject
@@ -232,7 +221,7 @@ describe('FirebaseListFactory', () => {
       it('startAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByValue: true,
             startAt: subject
@@ -245,7 +234,7 @@ describe('FirebaseListFactory', () => {
       it('endAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByValue: true,
             endAt: subject
@@ -269,7 +258,7 @@ describe('FirebaseListFactory', () => {
       it('equalTo - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByKey: true,
             equalTo: subject
@@ -282,7 +271,7 @@ describe('FirebaseListFactory', () => {
       it('startAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByKey: true,
             startAt: subject
@@ -295,7 +284,7 @@ describe('FirebaseListFactory', () => {
       it('endAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByKey: true,
             endAt: subject
@@ -318,7 +307,7 @@ describe('FirebaseListFactory', () => {
       it('equalTo - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByKey: true,
             equalTo: subject
@@ -331,7 +320,7 @@ describe('FirebaseListFactory', () => {
       it('startAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByKey: true,
             startAt: subject
@@ -344,7 +333,7 @@ describe('FirebaseListFactory', () => {
       it('endAt - should re-run a query when the observable value has emitted', (done: any) => {
 
         const subject = new Subject();
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByKey: true,
             endAt: subject
@@ -360,7 +349,7 @@ describe('FirebaseListFactory', () => {
   describe('shape', () => {
 
     it('should have a a FirebaseListObservable shape when queried', () => {
-        const observable = FirebaseListFactory(questionsPath, {
+        const observable = FirebaseListFactory(app.database().ref(questionsPath), {
           query: {
             orderByChild: 'height',
             equalTo: '1'
@@ -390,9 +379,9 @@ describe('FirebaseListFactory', () => {
       val1 = { key: 'key1' };
       val2 = { key: 'key2' };
       val3 = { key: 'key3' };
-      firebase.database().ref().remove(done);
-      questions = FirebaseListFactory(`questions`);
-      questionsSnapshotted = FirebaseListFactory(`questionssnapshot`, { preserveSnapshot: true });
+      app.database().ref().remove(done);
+      questions = FirebaseListFactory(app.database().ref(`questions`));
+      questionsSnapshotted = FirebaseListFactory(app.database().ref(`questionssnapshot`), { preserveSnapshot: true });
       ref = questions.$ref;
       refSnapshotted = questionsSnapshotted.$ref;
     });
@@ -588,7 +577,7 @@ describe('FirebaseListFactory', () => {
 
 
     it('should call off on all events when disposed', (done: any) => {
-      const questionRef = firebase.database().ref().child('questions');
+      const questionRef = app.database().ref().child('questions');
       let firebaseSpy = spyOn(questionRef, 'off').and.callThrough();
       subscription = FirebaseListFactory(questionRef).subscribe(_ => {
         expect(firebaseSpy).not.toHaveBeenCalled();
@@ -694,7 +683,7 @@ describe('FirebaseListFactory', () => {
       })
       .run(() => {
         // Creating a new observable so that the current zone is captured.
-        subscription = FirebaseListFactory(`questions`)
+        subscription = FirebaseListFactory(app.database().ref(`questions`))
           .filter(d => d
             .map(v => v.$value)
             .indexOf('in-the-zone') > -1)
@@ -757,7 +746,7 @@ describe('FirebaseListFactory', () => {
         })
         .then(() => {
 
-          let query1 = FirebaseListFactory(`questions`, {
+          let query1 = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'data',
               startAt: { value: 0 }
@@ -765,7 +754,7 @@ describe('FirebaseListFactory', () => {
           });
           let promise1 = toPromise.call(take.call(query1, 1));
 
-          let query2 = FirebaseListFactory(`questions`, {
+          let query2 = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'data',
               startAt: { value: 0, key: 'val2' }
@@ -795,7 +784,7 @@ describe('FirebaseListFactory', () => {
         })
         .then(() => {
 
-          let query1 = FirebaseListFactory(`questions`, {
+          let query1 = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'data',
               equalTo: { value: 0 }
@@ -803,7 +792,7 @@ describe('FirebaseListFactory', () => {
           });
           let promise1 = toPromise.call(take.call(query1, 1));
 
-          let query2 = FirebaseListFactory(`questions`, {
+          let query2 = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'data',
               equalTo: { value: 0, key: 'val2' }
@@ -833,7 +822,7 @@ describe('FirebaseListFactory', () => {
         })
         .then(() => {
 
-          let query1 = FirebaseListFactory(`questions`, {
+          let query1 = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'data',
               endAt: { value: 0 }
@@ -841,7 +830,7 @@ describe('FirebaseListFactory', () => {
           });
           let promise1 = toPromise.call(take.call(query1, 1));
 
-          let query2 = FirebaseListFactory(`questions`, {
+          let query2 = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'data',
               endAt: { value: 0, key: 'val2' }
@@ -871,7 +860,7 @@ describe('FirebaseListFactory', () => {
         .then(() => {
 
           let subject = new Subject<boolean>();
-          let query = FirebaseListFactory(`questions`, {
+          let query = FirebaseListFactory(app.database().ref(`questions`), {
             query: {
               orderByChild: 'even',
               equalTo: subject

--- a/src/database/firebase_list_factory.ts
+++ b/src/database/firebase_list_factory.ts
@@ -6,33 +6,15 @@ import { FirebaseListObservable } from './firebase_list_observable';
 import { Observer } from 'rxjs/Observer';
 import { observeOn } from 'rxjs/operator/observeOn';
 import { observeQuery } from './query_observable';
-import { Query, FirebaseListFactoryOpts, PathReference, QueryReference, DatabaseQuery, DatabaseReference } from '../interfaces';
+import { Query, FirebaseListFactoryOpts, DatabaseReference, DatabaseQuery } from '../interfaces';
 import { switchMap } from 'rxjs/operator/switchMap';
 import { map } from 'rxjs/operator/map';
 
 export function FirebaseListFactory (
-  pathRef: PathReference,
+  ref: DatabaseReference,
   { preserveSnapshot, query = {} } :FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
 
-  let ref: QueryReference;
-
-  utils.checkForUrlOrFirebaseRef(pathRef, {
-    isUrl: () => {
-      const path = pathRef as string;
-      if(utils.isAbsoluteUrl(path)) {
-        ref = firebase.database().refFromURL(path)
-      } else {
-        ref = firebase.database().ref(path);
-      } 
-    },
-    isRef: () => ref = <DatabaseReference>pathRef,
-    isQuery: () => ref = <DatabaseQuery>pathRef,
-  });
-
-  // if it's just a reference or string, create a regular list observable
-  if ((utils.isFirebaseRef(pathRef) ||
-       utils.isString(pathRef)) &&
-       utils.isEmptyObject(query)) {
+  if (utils.isEmptyObject(query)) {
     return firebaseListObservable(ref, { preserveSnapshot });
   }
 
@@ -119,7 +101,7 @@ export function FirebaseListFactory (
 }
 
 /**
- * Creates a FirebaseListObservable from a reference or query. Options can be provided as a second 
+ * Creates a FirebaseListObservable from a reference or query. Options can be provided as a second
  * parameter. This function understands the nuances of the Firebase SDK event ordering and other
  * quirks. This function takes into account that not all .on() callbacks are guaranteed to be
  * asynchonous. It creates a initial array from a promise of ref.once('value'), and then starts

--- a/src/database/firebase_object_factory.spec.ts
+++ b/src/database/firebase_object_factory.spec.ts
@@ -36,20 +36,9 @@ describe('FirebaseObjectFactory', () => {
 
   describe('<constructor>', () => {
 
-    it('should accept a Firebase db url in the constructor', () => {
-      const object = FirebaseObjectFactory(`questions`);
-      expect(object instanceof FirebaseObjectObservable).toBe(true);
-    });
-
     it('should accept a Firebase db ref in the constructor', () => {
-      const object = FirebaseObjectFactory(firebase.database().ref().child(`questions`));
+      const object = FirebaseObjectFactory(app.database().ref().child(`questions`));
       expect(object instanceof FirebaseObjectObservable).toBe(true);
-    });
-
-    it('should take an absolute url in the constructor', () => {
-      const absoluteUrl = COMMON_CONFIG.databaseURL + '/questions/one';
-      const list = FirebaseObjectFactory(absoluteUrl);
-      expect(list instanceof FirebaseObjectObservable).toBe(true);
     });
 
   });
@@ -58,9 +47,9 @@ describe('FirebaseObjectFactory', () => {
 
     beforeEach((done: any) => {
       i = Date.now();
-      ref = firebase.database().ref().child(`questions/${i}`);
+      ref = app.database().ref().child(`questions/${i}`);
       nextSpy = nextSpy = jasmine.createSpy('next');
-      observable = FirebaseObjectFactory(`questions/${i}`);
+      observable = FirebaseObjectFactory(app.database().ref(`questions/${i}`));
       ref.remove(done);
     });
 
@@ -118,7 +107,7 @@ describe('FirebaseObjectFactory', () => {
     });
 
     it('should emit snapshots if preserveSnapshot option is true', (done: any) => {
-      observable = FirebaseObjectFactory(`questions/${i}`, { preserveSnapshot: true });
+      observable = FirebaseObjectFactory(app.database().ref(`questions/${i}`), { preserveSnapshot: true });
       ref.remove(() => {
         ref.set('preserved snapshot!', () => {
           subscription = observable.subscribe(data => {
@@ -131,7 +120,7 @@ describe('FirebaseObjectFactory', () => {
 
 
     it('should call off on all events when disposed', () => {
-      const dbRef = firebase.database().ref();
+      const dbRef = app.database().ref();
       let firebaseSpy = spyOn(dbRef, 'off');
       subscription = FirebaseObjectFactory(dbRef).subscribe();
       expect(firebaseSpy).not.toHaveBeenCalled();
@@ -145,7 +134,7 @@ describe('FirebaseObjectFactory', () => {
       })
       .run(() => {
         // Creating a new observable so that the current zone is captured.
-        subscription = FirebaseObjectFactory(`questions/${i}`)
+        subscription = FirebaseObjectFactory(app.database().ref(`questions/${i}`))
           .filter(d => d.$value === 'in-the-zone')
           .subscribe(data => {
             expect(Zone.current.name).toBe('newZone');

--- a/src/database/firebase_object_factory.ts
+++ b/src/database/firebase_object_factory.ts
@@ -4,25 +4,11 @@ import { observeOn } from 'rxjs/operator/observeOn';
 import * as firebase from 'firebase/app';
 import 'firebase/database';
 import * as utils from '../utils';
-import { FirebaseObjectFactoryOpts, PathReference, DatabaseReference } from '../interfaces';
+import { FirebaseObjectFactoryOpts, DatabaseReference } from '../interfaces';
 
 export function FirebaseObjectFactory (
-  pathRef: PathReference,
+  ref: DatabaseReference,
   { preserveSnapshot }: FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
-
-  let ref: DatabaseReference;
-
-  utils.checkForUrlOrFirebaseRef(pathRef, {
-    isUrl: () => {
-      const path = pathRef as string;
-      if(utils.isAbsoluteUrl(path)) {
-        ref = firebase.database().refFromURL(path)
-      } else {
-        ref = firebase.database().ref(path);
-      }
-    },
-    isRef: () => ref = <DatabaseReference>pathRef
-  });
 
   const objectObservable = new FirebaseObjectObservable((obs: Observer<any>) => {
     let fn = ref.on('value', (snapshot: firebase.database.DataSnapshot) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,19 +73,6 @@ export function unwrapMapFn (snapshot:firebase.database.DataSnapshot): AFUnwrapp
   return unwrapped;
 }
 
-export function checkForUrlOrFirebaseRef(urlOrRef: string | firebase.database.Reference | firebase.database.Query, cases: CheckUrlRef): any {
-  if (isString(urlOrRef)) {
-    return cases.isUrl();
-  }
-  if (isFirebaseRef(urlOrRef)) {
-    return cases.isRef();
-  }
-  if (isFirebaseQuery(urlOrRef)) {
-    return cases.isQuery();
-  }
-  throw new Error('Provide a url or a Firebase database reference');
-}
-
 export function stripTrailingSlash(value: string): string {
   // Is the last char a /
   if (value.substring(value.length - 1, value.length) === '/') {
@@ -118,7 +105,7 @@ export function isAbsoluteUrl(url: string) {
 }
 
 /**
- * Returns a database reference given a Firebase App and an 
+ * Returns a database reference given a Firebase App and an
  * absolute or relative path.
  * @param app - Firebase App
  * @param path - Database path, relative or absolute


### PR DESCRIPTION
Closes #907

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #907
   - Docs included?: no 
   - Test units included?: no 
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

Observable factories now receive `DataReference` parameters and cannot be passed path strings. See #907.