### PR TITLE
AngularFireAuth.authState proposal

### DIFF
--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -80,7 +80,7 @@ describe('AngularFireAuth', () => {
   });
 
   it('should have the Firebase Auth instance', () => {
-    expect(afAuth.auth).toBeDefined();
+    expect(afAuth.Auth).toBeDefined();
   });
 
   it('should emit auth updates through user', (done: any) => {

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -50,8 +50,8 @@ describe('AngularFireAuth', () => {
     })();
 
     mockAuthState = new Subject<firebase.User>();
-    spyOn(afAuth, 'authState').and.returnValue(mockAuthState);
-    afAuth.authState = mockAuthState;
+    spyOn(afAuth, 'user').and.returnValue(mockAuthState);
+    afAuth.user = mockAuthState;
   });
 
   afterEach(done => {
@@ -65,7 +65,7 @@ describe('AngularFireAuth', () => {
         name: 'ngZone'
       });
       ngZone.run(() => {
-        const subs = afAuth.authState.subscribe(user => {
+        const subs = afAuth.user.subscribe(user => {
           expect(Zone.current.name).toBe('ngZone');
           done();
         }, done.fail);
@@ -83,11 +83,11 @@ describe('AngularFireAuth', () => {
     expect(afAuth.auth).toBeDefined();
   });
 
-  it('should emit auth updates through authState', (done: any) => {
+  it('should emit auth updates through user', (done: any) => {
     let count = 0;
 
     // Check that the first value is null and second is the auth user
-    const subs = afAuth.authState.subscribe(user => {
+    const subs = afAuth.user.subscribe(user => {
       if (count === 0) {
         expect(user).toBe(null);
         count = count + 1;

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -19,10 +19,10 @@ export class AngularFireAuth {
   /**
    * Observable of authentication state
    */
-  authState: Observable<firebase.User>;
+  user: Observable<firebase.User>;
 
   constructor(public app: FirebaseApp) {
-    this.authState = FirebaseAuthStateObservable(app);
+    this.user = FirebaseAuthStateObservable(app);
     this.auth = app.auth();
   }
 

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -14,7 +14,7 @@ export class AngularFireAuth {
   /**
    * Firebase Auth instance
    */
-  auth: firebase.auth.Auth;
+  Auth: firebase.auth.Auth;
 
   /**
    * Observable of authentication state
@@ -23,7 +23,7 @@ export class AngularFireAuth {
 
   constructor(public app: FirebaseApp) {
     this.user = FirebaseAuthStateObservable(app);
-    this.auth = app.auth();
+    this.Auth = app.auth();
   }
 
 }

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -12,7 +12,14 @@ import * as utils from '../utils';
 @Injectable()
 export class AngularFireDatabase {
 
-  constructor(public app: FirebaseApp) {}
+  /**
+   * Firebase Database instance
+   */
+  Database: firebase.database.Database;
+
+  constructor(public app: FirebaseApp) {
+    this.Database = app.database();
+  }
 
   list(pathOrRef: PathReference, opts?:FirebaseListFactoryOpts):FirebaseListObservable<any[]> {
     const ref = utils.getRef(this.app, pathOrRef);


### PR DESCRIPTION
### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

While writing the docs for the `@next` release #901 and updating my example projects, I found the API, in particularly `authState` to be a bit awkward. @davideast since it's only an observable for `firebase.User` why don't we just name it `user` rather than `authState`?

Also having the `auth` helper on AngularFireAuth seemed off, especially with the naming. **If** we do want to provide a helper to `app.auth()`, I'd recommend we call it `Auth` but I'm not sure this provides a lot of value. To be consistent, I added `Database` to `AngularFireDatabase`.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

```ts
export class App {
  user: Observable<firebase.User>;
  constructor(auth: AngularFireAuth) {
    // this.user = auth.authState;
    this.user = auth.user;
  }
  login() {
    // this.auth.auth.signInWithPopup(new firebase.auth.GoogleAuthProvider())
    this.auth.Auth.signInWithPopup(new firebase.auth.GoogleAuthProvider());
  }
  logout() {
     // this.auth.auth.signOut();
     this.auth.Auth.signOut();
  }
}
```

