### PR TITLE
docs: Fix missing identifier

### DIFF
--- a/docs/version-4-upgrade.md
+++ b/docs/version-4-upgrade.md
@@ -74,7 +74,7 @@ import { AngularFireAuthModule, AngularFireAuth } from 'angularfire2/auth';
 import { environment } from '../environments/environment';
 
 // Do not import from 'firebase' as you'd lose the tree shaking benefits
-import * from 'firebase/app';
+import * as firebase from 'firebase/app';
 
 
 @NgModule({


### PR DESCRIPTION
need to call the import something, right?

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: n/a
   - Docs included?: n/a
   - Test units included?: no
   - e2e tests included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? with changes, yes

### Description
Fixing a typo, missing the identifier for importing `*` from `firebase/app`
<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->