### PR TITLE
Fix H1 in Markdown

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,4 +1,4 @@
-#API Reference
+# API Reference
 
 **Work in progress. [See the developer guide](/docs/1-install-and-setup.md) for a comprehensive walkthrough of AngularFire2.**
 


### PR DESCRIPTION
Fixing spacing in an H1 so that Github's Markdown parser renders it appropriately.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: n/a/
   - Docs included?: n/a
   - Test units included?: n/a
   - e2e tests included?: n/a
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? n/a

### Description

Fixing spacing in an H1 so that Github's Markdown parser renders it appropriately.

### Code sample

n/a

