### PR TITLE
Change 'items' to 'cuisines'

### DIFF
--- a/docs/Auth-with-Ionic3-Angular4.md
+++ b/docs/Auth-with-Ionic3-Angular4.md
@@ -261,7 +261,7 @@ export class HomePage {
 
 ```
 
-*_Ensure you've `items` node in your database with some primitive data._
+*_Ensure you've `cuisines` node in your database with some primitive data._
 
 **Update** your `home.html` at `src/pages/home/home.html`, with following entry
 


### PR DESCRIPTION
According to the code above, the hint "Ensure you've 'items' node in you database..." should say "Ensure you've 'cuisines' node in you...", becuase afDB.list('/cuisines') referes to that node, not '/items'.

