### PR TITLE
fix(FirebaseApp): Return app if it exists

### DIFF
--- a/rollup-globals.js
+++ b/rollup-globals.js
@@ -7,5 +7,6 @@ export default (mod) => {
 
   if (mod === 'firebase') return 'firebase';
   if (mod === '@angular/core') return 'ng.core';
+  if (mod === '@angular/platform-browser') return 'ng.platformBrowser';
   if (mod === '@angular/core/testing') return 'ng.core.testing';
 }

--- a/src/angularfire2.spec.ts
+++ b/src/angularfire2.spec.ts
@@ -47,7 +47,7 @@ describe('angularfire', () => {
     it('should have the provided name', () => {
       expect(app.name).toBe(APP_NAME);
     })
-    it('should use an already intialized firebase app if it exists', async(() => {
+    it('should use an already intialized firebase app if it exists', done => {
       @NgModule({
         imports: [
           AngularFireModule.initializeApp(COMMON_CONFIG, APP_NAME),
@@ -65,7 +65,10 @@ describe('angularfire', () => {
         .then(moduleRef => {
           const ref = moduleRef.injector.get(FirebaseApp);
           expect(ref.name).toEqual(app.name);
+        }).then(done, e => {
+          fail(e);
+          done()
         });
-    }))
+    })
   });
 });

--- a/src/angularfire2.spec.ts
+++ b/src/angularfire2.spec.ts
@@ -1,9 +1,10 @@
 import * as firebase from 'firebase/app';
-import { TestBed, inject } from '@angular/core/testing';
-import { ReflectiveInjector, Provider } from '@angular/core';
+import { TestBed, inject, withModule, async } from '@angular/core/testing';
+import { ReflectiveInjector, Provider, PlatformRef, NgModule, Compiler, ApplicationRef, CompilerFactory } from '@angular/core';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from './angularfire2';
 import { Subscription } from 'rxjs/Subscription';
 import { COMMON_CONFIG } from './test-config';
+import { BrowserModule } from '@angular/platform-browser';
 
 describe('angularfire', () => {
   let subscription:Subscription;
@@ -11,6 +12,8 @@ describe('angularfire', () => {
   let rootRef: firebase.database.Reference;
   let questionsRef: firebase.database.Reference;
   let listOfQuestionsRef: firebase.database.Reference;
+  let defaultPlatform: PlatformRef;
+
   const APP_NAME = 'super-awesome-test-firebase-app-name';
 
   beforeEach(() => {
@@ -19,11 +22,12 @@ describe('angularfire', () => {
       imports: [AngularFireModule.initializeApp(COMMON_CONFIG, APP_NAME)]
     });
 
-    inject([FirebaseApp], (_app: FirebaseApp) => {
+    inject([FirebaseApp, PlatformRef], (_app: FirebaseApp, _platform: PlatformRef) => {
       app = _app;
       rootRef = app.database().ref();
       questionsRef = rootRef.child('questions');
       listOfQuestionsRef = rootRef.child('list-of-questions');
+      defaultPlatform = _platform;
     })();
 
   });
@@ -43,5 +47,25 @@ describe('angularfire', () => {
     it('should have the provided name', () => {
       expect(app.name).toBe(APP_NAME);
     })
+    it('should use an already intialized firebase app if it exists', async(() => {
+      @NgModule({
+        imports: [
+          AngularFireModule.initializeApp(COMMON_CONFIG, APP_NAME),
+          BrowserModule
+        ]})
+      class MyModule {
+        ngDoBootstrap() {}
+      }
+
+      const compilerFactory: CompilerFactory =
+          defaultPlatform.injector.get(CompilerFactory, null);
+      const moduleFactory = compilerFactory.createCompiler().compileModuleSync(MyModule);
+
+      defaultPlatform.bootstrapModuleFactory(moduleFactory)
+        .then(moduleRef => {
+          const ref = moduleRef.injector.get(FirebaseApp);
+          expect(ref.name).toEqual(app.name);
+        });
+    }))
   });
 });

--- a/src/app/firebase.app.module.ts
+++ b/src/app/firebase.app.module.ts
@@ -23,6 +23,10 @@ export function _firebaseAppFactory(config: FirebaseAppConfig, appName?: string)
     }
   }
   catch (e) {
+    if (e.code === "app/duplicate-app") {
+      return firebase.app(e.name);
+    }
+
     return firebase.app(null);
   }
 }


### PR DESCRIPTION
### Checklist

-  [x] Issue number for this PR: #518, #235
-  [ ] Docs included?: no
-  [x] Test units included?: yes
-  [ ] e2e tests included?: no
-  [x] In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully?

### Description

This supports HMR by returning the existing app instance if it was already initialized. (See #518, #235)

Fixes errors such as
```
No App '[DEFAULT]' has been created - call App.initializeApp() (app/no-app).
```