### PR TITLE
fix(typings): add ambient zone typings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 *.spec.*
 bundles/test.umd.js
+test-config.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 sudo: false
 node_js:
 - 'node'
+dist: precise
 
 addons:
   firefox: latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularfire2",
-  "version": "4.0.0-rc.2",
+  "version": "4.0.0-rc.2-next",
   "description": "The official library of Firebase and Angular.",
   "private": true,
   "scripts": {

--- a/src/core/angularfire2.ts
+++ b/src/core/angularfire2.ts
@@ -4,7 +4,6 @@ import { Injectable, InjectionToken, OpaqueToken, NgModule } from '@angular/core
 import { Subscription } from 'rxjs/Subscription';
 import { Scheduler } from 'rxjs/Scheduler';
 import { queue } from 'rxjs/scheduler/queue';
-import 'zone.js';
 
 export interface FirebaseAppConfig {
   apiKey?: string;
@@ -43,7 +42,9 @@ export class AngularFireModule {
  * with zones.
  */
 export class ZoneScheduler {
-  constructor(public zone: Zone) {}
+
+  // TODO: Correctly add ambient zone typings instead of using any.
+  constructor(public zone: any) {}
 
   schedule(...args: any[]): Subscription {
     return <Subscription>this.zone.run(() => queue.schedule.apply(queue, args));


### PR DESCRIPTION
Zone typings are breaking user app builds. Currently typing `Zone` to any until we have a better solution.