### PR TITLE
docs(readme): rename Ionic 2/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,6 @@ productive with AngularFire2.
 3. [Retrieving data as lists - FirebaseListObservable](docs/3-retrieving-data-as-lists.md)
 4. [Querying lists](docs/4-querying-lists.md)
 5. [User Authentication - FirebaseAuthentication](docs/5-user-authentication.md)
-6. [Using AngularFire2 with Ionic 2](docs/Auth-with-Ionic2.md)
-7. [Using AngularFire2 with Ionic 3 and Angular 4](docs/Auth-with-Ionic3-Angular4.md)
+6. [Using AngularFire2 with Ionic](docs/Auth-with-Ionic2.md)
+7. [Using AngularFire2 with Ionic and Angular 4](docs/Auth-with-Ionic3-Angular4.md)
 8. [Deploying AngularFire2 to FirebaseHosting](docs/7-deploying-angularfire-to-firebase.md)


### PR DESCRIPTION
### Description
Since Ionic 3.0 we call it just Ionic (like Angular) :)

PS: I will rewrite the tutorial later. I think one guide is enough for Ionic + Angular > 4.x