### PR TITLE
docs(Auth-with-Ionic3-Angular4) Fix Providers

### DIFF
--- a/docs/Auth-with-Ionic3-Angular4.md
+++ b/docs/Auth-with-Ionic3-Angular4.md
@@ -182,9 +182,9 @@ and add the following three entries.
 
 >2) Define your firebaseConfig constant.
 
->3) Initialize your app, by adding AngularFireModule in the "imports" array in @NgModule
+>3) Initialize your app, by adding AngularFireModule and AngularFireAuthModule in the "imports" array in @NgModule
 
->3) Also, add AngularFireDatabaseModule in the "imports" array in @NgModule
+>4) Also, add AngularFireDatabase in the "providers" array in @NgModule
 
 your `app.module.ts` file should look something like this.
 

--- a/docs/Auth-with-Ionic3-Angular4.md
+++ b/docs/Auth-with-Ionic3-Angular4.md
@@ -231,6 +231,7 @@ export const firebaseConfig = {
   providers: [
     StatusBar,
     SplashScreen,
+    AngularFireDatabase,
     {provide: ErrorHandler, useClass: IonicErrorHandler}
   ]
 })


### PR DESCRIPTION
AngularFireDatabase should be declared into providers section in app.module in order to be used by components

**Checklist**

-Issue number for this PR: n/a
-Docs included?: yes (is a doc update)
-Test units included?: none affected
-e2e tests included?: none affected
-In a clean directory, npm install, npm run build, and npm test run successfully? n/a

**Description**
In order to use AngularFireDatabase service you must first declare it in providers section in app.module.
Fixed the code, corrected and updated the instructions so that they reflect the code explained.