### PR TITLE
docs(afs): Fix the stackblitz link on the querying example

### DIFF
--- a/docs/firestore/querying-collections.md
+++ b/docs/firestore/querying-collections.md
@@ -77,7 +77,7 @@ size$.next('small');
 
 **Example app:**
  
-[See this example in action on StackBlitz](https://stackblitz.com/edit/angularfire-db-api-bimovw).
+[See this example in action on StackBlitz](https://stackblitz.com/edit/angularfire-db-api-fbad9p).
 
 ```ts
 import { Component } from '@angular/core';


### PR DESCRIPTION
I must have made that Stackblitz without logging into Github as I couldn't edit it today. I've linked a new one which I've updated with Cloud Firestore.