### PR TITLE
fix(afs): Don't filter empty changes (allow for null set), closes #1184

### DIFF
--- a/src/firestore/collection/changes.ts
+++ b/src/firestore/collection/changes.ts
@@ -28,8 +28,7 @@ export function sortedChanges(query: firebase.firestore.Query, events: firebase.
   return fromCollectionRef(query)
     .map(changes => changes.payload.docChanges)
     .scan((current, changes) => combineChanges(current, changes, events), [])
-    .map(changes => changes.map(c => ({ type: c.type, payload: c })))
-    .filter(changes => changes.length > 0);
+    .map(changes => changes.map(c => ({ type: c.type, payload: c })));
 }
 
 /**
@@ -60,7 +59,6 @@ export function combineChange(combined: firebase.firestore.DocumentChange[], cha
       combined.splice(change.newIndex, 0, change);
       break;
     case 'modified':
-      debugger;
       // When an item changes position we first remove it
       // and then add it's new position
       if(change.oldIndex !== change.newIndex) {

--- a/tools/build.js
+++ b/tools/build.js
@@ -14,6 +14,7 @@ const GLOBALS = {
   'rxjs/Subject': 'Rx',
   'rxjs/Observer': 'Rx',
   'rxjs/Subscription': 'Rx',
+  'rxjs/BehaviorSubject': 'Rx',
   'rxjs/observable/merge': 'Rx.Observable',
   'rxjs/operator/share': 'Rx.Observable.prototype',
   'rxjs/operator/observeOn': 'Rx.Observable.prototype',


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #1184
   - Docs included?: n/a
   - Test units included?: yes
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

Per #1184 AFS is filtering empty sets from valueChanges(), this has been fixed.