### PR TITLE
docs: fix object spread typing and mis-named variables

### DIFF
--- a/docs/firestore/collections.md
+++ b/docs/firestore/collections.md
@@ -139,6 +139,7 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 
 export interface Shirt { name: string; price: number; }
+export interface ShirtId extends Shirt { id: string; }
 
 @Component({
   selector: 'app-root',
@@ -152,14 +153,18 @@ export interface Shirt { name: string; price: number; }
 })
 export class AppComponent {
   private shirtCollection: AngularFirestoreCollection<Shirt>;
-  shirts: Observable<Shirt[]>;
+  shirts: Observable<ShirtId[]>;
   constructor(private readonly afs: AngularFirestore) {
     this.shirtCollection = afs.collection<Shirt>('shirts');
     // .snapshotChanges() returns a DocumentChangeAction[], which contains
     // a lot of information about "what happened" with each change. If you want to
     // get the data and the id use the map operator.
     this.shirts = this.shirtCollection.snapshotChanges().map(actions => {
-      return actions.map(a => ({ id: a.payload.doc.id(), ...a.payload.doc.data() }))
+      return actions.map(a => {
+        const data = a.payload.doc.data() as Shirt;
+        const id = a.payload.doc.id;
+        return { id, ...data };
+      });
     });
   }
 }
@@ -179,6 +184,7 @@ import { AngularFirestore, AngularFirestoreCollection } from 'angularfire2/fires
 import { Observable } from 'rxjs/Observable';
 
 export interface AccountDeposit { description: string; amount: number; }
+export interface AccountDepoistId extends AccountDeposit { id: string; }
 
 @Component({
   selector: 'app-root',
@@ -191,13 +197,17 @@ export interface AccountDeposit { description: string; amount: number; }
   `
 })
 export class AppComponent {
-  private depositCollection: AngularFirestoreCollection<Shirt>;
-  deposits: Observable<Shirt[]>;
+  private depositCollection: AngularFirestoreCollection<AccountDeposit>;
+  deposits: Observable<AccountDepositId[]>;
   constructor(private readonly afs: AngularFirestore) {
     this.depositCollection = afs.collection<AccountDeposit>('deposits');
     this.deposits = this.shirtCollection.stateChanges(['added'])
       .map(actions => {
-        return actions.map(a => ({ id: a.payload.doc.id(), ...a.payload.doc.data() }))
+        return actions.map(a => {
+          const data = a.payload.doc.data() as AccountDeposit;
+          const id = a.payload.doc.id;
+          return { id, ...data };
+        })
       });
   }
 }
@@ -219,6 +229,7 @@ import { AngularFirestore, AngularFirestoreCollection } from 'angularfire2/fires
 import { Observable } from 'rxjs/Observable';
 
 export interface AccountLogItem { description: string; amount: number; }
+export interface AccountLogItemId extends AccountLogItem { id: string; }
 
 @Component({
   selector: 'app-root',
@@ -232,12 +243,16 @@ export interface AccountLogItem { description: string; amount: number; }
 })
 export class AppComponent {
   private accountLogCollection: AngularFirestoreCollection<AccountLogItem>;
-  accountLogs: Observable<AccountLogItem[]>;
+  accountLogs: Observable<AccountLogItemId[]>;
   constructor(private readonly afs: AngularFirestore) {
-    this.accountLogCollection = afs.collection<AccountDeposit>('accountLog');
+    this.accountLogCollection = afs.collection<AccountLogItem>('accountLog');
     this.accountLogs = this.shirtCollection.auditTrail()
       .map(actions => {
-        return actions.map(a => ({ id: a.payload.doc.id(), ...a.payload.doc.data() }))
+        return actions.map(a => {
+          const data = a.payload.doc.data() as AccountLogItem;
+          const id = a.payload.doc.id;
+          return { id, ...data };
+        })
       });
   }
 }


### PR DESCRIPTION
There was an issue with typing (I think) using the current way of returning a new object with the doc.id included. This method ensures that what gets returned is properly typed.

This method was used on two other examples (`.stateChanges()` and `auditTrail()`) so those were updated as well. I also found a handful of mis-named types (assume they were missed from copy/pasting) and so I updated those as well.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #1187 
   - Docs included?: n/a
   - Test units included?: n/a
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

