### PR TITLE
fix(afs): remove debugger statement from collection/changes.ts

### DIFF
--- a/src/firestore/collection/changes.ts
+++ b/src/firestore/collection/changes.ts
@@ -60,7 +60,6 @@ export function combineChange(combined: firebase.firestore.DocumentChange[], cha
       combined.splice(change.newIndex, 0, change);
       break;
     case 'modified':
-      debugger;
       // When an item changes position we first remove it
       // and then add it's new position
       if(change.oldIndex !== change.newIndex) {


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: n/a
   - Docs included?: not required
   - Test units included?: not required
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

Removed a `debugger` statement that in changes.ts that was causing the browser to pause in debug mode whenever the modified document change occurred. 



