### PR TITLE
docs(typo): firestore module was included twice in documentation

### DIFF
--- a/docs/install-and-setup.md
+++ b/docs/install-and-setup.md
@@ -99,7 +99,6 @@ export class AppModule {}
 After adding the AngularFireModule you also need to add modules for the individual @NgModules that your application needs.
  - AngularFirestoreModule
  - AngularFireAuthModule
- - AngularFirestoreModule
  - AngularFireDatabaseModule
  - AngularFireStorageModule (Future release)
  - AngularFireMessagingModule (Future release)


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: N/A
   - Docs included?: yes
   - Test units included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

[Install-and-setup](https://github.com/angular/angularfire2/blob/master/docs/install-and-setup.md) had AngulaFireStoreModule twice in list, in step 6. I removed one of them. 
