### PR TITLE
Problem with 'key' and '$key' in migration guide.

### DIFF
--- a/docs/version-5-upgrade.md
+++ b/docs/version-5-upgrade.md
@@ -45,7 +45,7 @@ constructor(afDb: AngularFireDatabase) {
     const $key = action.payload.key;
     const data = { $key, ...action.payload.val() };
     return data;
-  }).subscribe(item => console.log(item.key));
+  }).subscribe(item => console.log(item.$key));
 }
 ```
 


### PR DESCRIPTION
Problem with 'key' and '$key' in migration guide.

### Checklist

   - Issue number for this PR: #nnn (required) 
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? (yes/no; required)

### Description
Updating the migration guide, to correct a (possible) error: Problem with 'key' and '$key' in migration guide. Fix in docs for variable name consistency.