### PR TITLE
feat(afs): export interfaces

### DIFF
--- a/src/firestore/public_api.ts
+++ b/src/firestore/public_api.ts
@@ -4,3 +4,4 @@ export * from './collection/collection';
 export * from './document/document';
 export * from './collection/changes';
 export * from './observable/fromRef';
+export * from './interfaces'


### PR DESCRIPTION
Closes #1249

All interface in `'./interfaces'` are already exposed by other API's so using `export *` isn't introducing anything new.