### PR TITLE
fix(afs): catch error when enabling persistence

### DIFF
--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -100,8 +100,8 @@ export class AngularFirestore {
   constructor(public app: FirebaseApp, shouldEnablePersistence) {
     this.firestore = app.firestore();
 
-    this.persistenceEnabled$ = shouldEnablePersistence ? 
-      from(app.firestore().enablePersistence().then(() => true)) :
+    this.persistenceEnabled$ = shouldEnablePersistence ?
+      from(app.firestore().enablePersistence().then(() => true, () => false)) :
       from(new Promise((res, rej) => { res(false); }));
   }
   


### PR DESCRIPTION
### Checklist
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description
Instead of getting an "Uncaught Promise" error in console, this will set the persistanceEnabled$ observable properly
