### PR TITLE
Allow document set options. Fixes #1332

### DIFF
--- a/src/firestore/document/document.ts
+++ b/src/firestore/document/document.ts
@@ -15,20 +15,20 @@ import { AngularFirestoreCollection } from '../collection/collection';
 
 /**
  * AngularFirestoreDocument service
- * 
- * This class creates a reference to a Firestore Document. A reference is provided in 
+ *
+ * This class creates a reference to a Firestore Document. A reference is provided in
  * in the constructor. The class is generic which gives you type safety for data update
  * methods and data streaming.
- * 
+ *
  * This class uses Symbol.observable to transform into Observable using Observable.from().
- * 
+ *
  * This class is rarely used directly and should be created from the AngularFirestore service.
- * 
+ *
  * Example:
- * 
+ *
  * const fakeStock = new AngularFirestoreDocument<Stock>(firebase.firestore.doc('stocks/FAKE'));
  * await fakeStock.set({ name: 'FAKE', price: 0.01 });
- * fakeStock.valueChanges().map(snap => { 
+ * fakeStock.valueChanges().map(snap => {
  *   if(snap.exists) return snap.data();
  *   return null;
  * }).subscribe(value => console.log(value));
@@ -40,21 +40,22 @@ export class AngularFirestoreDocument<T> {
   /**
    * The contstuctor takes in a DocumentReference to provide wrapper methods
    * for data operations, data streaming, and Symbol.observable.
-   * @param ref 
+   * @param ref
    */
   constructor(public ref: firebase.firestore.DocumentReference) { }
 
   /**
    * Create or overwrite a single document.
    * @param data
+   * @param options
    */
-  set(data: T): Promise<void> {
-    return this.ref.set(data);
+  set(data: T, options?: firebase.firestore.SetOptions): Promise<void> {
+    return this.ref.set(data, options);
   }
 
   /**
    * Update some fields of a document without overwriting the entire document.
-   * @param data 
+   * @param data
    */
   update(data: Partial<T>): Promise<void> {
     return this.ref.update(data);
@@ -70,8 +71,8 @@ export class AngularFirestoreDocument<T> {
   /**
    * Create a reference to a sub-collection given a path and an optional query
    * function.
-   * @param path 
-   * @param queryFn 
+   * @param path
+   * @param queryFn
    */
   collection<T>(path: string, queryFn?: QueryFn): AngularFirestoreCollection<T> {
     const collectionRef = this.ref.collection(path);


### PR DESCRIPTION
Add options parameter to document `set` method and pass that to `this.ref.set`. 

It looks like my editor removed extra whitespace on the file. What is the style guide rules for trailing whitespace? 