### PR TITLE
Update RTDB docs to reflect 5.0 changes

### DIFF
--- a/docs/rtdb/lists.md
+++ b/docs/rtdb/lists.md
@@ -91,7 +91,7 @@ AngularFire provides methods that stream data back as redux compatible actions. 
 **When would you not use it?** - When you need a more complex data structure than an array or if you need to process changes as they occur. This array is synchronized with the remote and local changes in the Firebase Database.
 
 ### `stateChanges()`
-**What is it?** - Returns an Observable of the most recent change as a `AngularFireAction`. 
+**What is it?** - Returns an Observable of the most recent change as an `AngularFireAction`. 
 
 **Why would you use it?** - The above methods return a singular `AngularFireAction` from each child event that occurs. `stateChanges()` emits changes as they occur rather than syncing the query order. This works well for ngrx integrations as you can build your own data structure in your reducer methods.
 

--- a/docs/rtdb/lists.md
+++ b/docs/rtdb/lists.md
@@ -91,9 +91,9 @@ AngularFire provides methods that stream data back as redux compatible actions. 
 **When would you not use it?** - When you need a more complex data structure than an array or if you need to process changes as they occur. This array is synchronized with the remote and local changes in the Firebase Database.
 
 ### `stateChanges()`
-**What is it?** - Returns an Observable of the most recent changes as a `AngularFireAction[]`. 
+**What is it?** - Returns an Observable of the most recent change as a `AngularFireAction`. 
 
-**Why would you use it?** - The above methods return a synchronized array sorted in query order. `stateChanges()` emits changes as they occur rather than syncing the query order. This works well for ngrx integrations as you can build your own data structure in your reducer methods.
+**Why would you use it?** - The above methods return a singular `AngularFireAction` from each child event that occurs. `stateChanges()` emits changes as they occur rather than syncing the query order. This works well for ngrx integrations as you can build your own data structure in your reducer methods.
 
 **When would you not use it?** - When you just need a list of data. This is a more advanced usage of `AngularFireDatabase`. 
 

--- a/docs/rtdb/objects.md
+++ b/docs/rtdb/objects.md
@@ -158,7 +158,7 @@ export class AppComponent {
 ```
 
 ## Retrieving the snapshot
-AngularFire `valueChanges()` unwraps the Firebase DataSnapshot by default, but you can get the data as the original snapshot by using the `snapshowChanges()` option instead.
+AngularFire `valueChanges()` unwraps the Firebase DataSnapshot by default, but you can get the data as the original snapshot by using the `snapshotChanges()` option instead.
 
 ```ts
 this.itemRef = db.object('item');

--- a/docs/rtdb/objects.md
+++ b/docs/rtdb/objects.md
@@ -157,17 +157,8 @@ export class AppComponent {
 }
 ```
 
-## Meta-fields on the object
-Data retrieved from the object binding contains special properties retrieved from the unwrapped Firebase DataSnapshot.
-
-| property |                    | 
-| ---------|--------------------| 
-| `$key`     | The key for each record. This is equivalent to each record's path in our database as it would be returned by `ref.key()`.|
-| `$value`   | If the data for this child node is a primitive (number, string, or boolean), then the record itself will still be an object. The primitive value will be stored under `$value` and can be changed and saved like any other field.|
-
-
 ## Retrieving the snapshot
-AngularFire unwraps the Firebase DataSnapshot by default, but you can get the data as the original snapshot by specifying the `preserveSnapshot` option. 
+AngularFire `valueChanges()` unwraps the Firebase DataSnapshot by default, but you can get the data as the original snapshot by using the `snapshowChanges()` option instead.
 
 ```ts
 this.itemRef = db.object('item');


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #1373 
   - Docs included?: yes
   - Test units included?: not needed, doc only change
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? not needed, doc only change

### Description

Per #1373 the docs needed to be updated to reflect the proper functionality of stateChanges() on RTDB as it functions different from Firestore. Also while making these changes I noticed objects.md still had some outdated information that referenced how pre 5.0 functioned. I wanted to clean this up with the current functionality.

