### PR TITLE
Fix for #1385 that was caused by firebase releasing 4.8.1

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,6 +1,4 @@
 import { NgModule, NgZone } from '@angular/core';
-import * as firebase from 'firebase/app';
-import 'firebase/auth';
 import { FirebaseApp, AngularFireModule } from 'angularfire2';
 import { AngularFireAuth } from './auth';
 

--- a/src/auth/auth.spec.ts
+++ b/src/auth/auth.spec.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
+import { User } from '@firebase/auth-types';
 import { ReflectiveInjector, Provider } from '@angular/core';
 import { Observable } from 'rxjs/Observable'
 import { Subject } from 'rxjs/Subject'
@@ -19,16 +20,16 @@ function authSkip(auth: Observable<any>, count: number): Observable<any> {
   return skip.call(auth, 1);
 }
 
-const firebaseUser = <firebase.User> {
+const firebaseUser = <User> {
   uid: '12345',
   providerData: [{ displayName: 'jeffbcrossyface' }]
 };
 
 describe('AngularFireAuth', () => {
-  let app: firebase.app.App;
+  let app: FBApp;
   let afAuth: AngularFireAuth;
   let authSpy: jasmine.Spy;
-  let mockAuthState: Subject<firebase.User>;
+  let mockAuthState: Subject<User>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -42,11 +43,11 @@ describe('AngularFireAuth', () => {
       afAuth = _auth;
     })();
 
-    mockAuthState = new Subject<firebase.User>();
+    mockAuthState = new Subject<User>();
     spyOn(afAuth, 'authState').and.returnValue(mockAuthState);
     spyOn(afAuth, 'idToken').and.returnValue(mockAuthState);
-    afAuth.authState = mockAuthState as Observable<firebase.User>;
-    afAuth.idToken = mockAuthState as Observable<firebase.User>;
+    afAuth.authState = mockAuthState as Observable<User>;
+    afAuth.idToken = mockAuthState as Observable<User>;
   });
 
   afterEach(done => {
@@ -104,7 +105,7 @@ describe('AngularFireAuth', () => {
 
   it('should emit auth updates through idToken', (done: any) => {
     let count = 0;
-    
+
     // Check that the first value is null and second is the auth user
     const subs = afAuth.idToken.subscribe(user => {
       if (count === 0) {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,5 +1,4 @@
-import * as firebase from 'firebase/app';
-import 'firebase/auth';
+import { FirebaseAuth, User } from '@firebase/auth-types';
 import { Injectable, NgZone } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { observeOn } from 'rxjs/operator/observeOn';
@@ -15,12 +14,12 @@ export class AngularFireAuth {
   /**
    * Firebase Auth instance
    */
-  public readonly auth: firebase.auth.Auth;
+  public readonly auth: FirebaseAuth;
 
   /**
    * Observable of authentication state; as of 4.0 this is only triggered via sign-in/out
    */
-  public readonly authState: Observable<firebase.User|null>;
+  public readonly authState: Observable<User|null>;
 
   /**
    * Observable of the signed-in user's ID token; which includes sign-in, sign-out, and token refresh events
@@ -36,7 +35,7 @@ export class AngularFireAuth {
     });
     this.authState = observeOn.call(authState$, new ZoneScheduler(Zone.current));
 
-    const idToken$ = new Observable<firebase.User|null>(subscriber => {
+    const idToken$ = new Observable<User|null>(subscriber => {
       const unsubscribe = this.auth.onIdTokenChanged(subscriber);
       return { unsubscribe };
     }).switchMap(user => {

--- a/src/core/angularfire2.spec.ts
+++ b/src/core/angularfire2.spec.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase/app';
+
+import { Reference } from '@firebase/database-types';
 import { TestBed, inject, withModule, async } from '@angular/core/testing';
 import { ReflectiveInjector, Provider, PlatformRef, NgModule, Compiler, ApplicationRef, CompilerFactory } from '@angular/core';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
@@ -9,9 +10,9 @@ import { BrowserModule } from '@angular/platform-browser';
 describe('angularfire', () => {
   let subscription:Subscription;
   let app: FirebaseApp;
-  let rootRef: firebase.database.Reference;
-  let questionsRef: firebase.database.Reference;
-  let listOfQuestionsRef: firebase.database.Reference;
+  let rootRef: Reference;
+  let questionsRef: Reference;
+  let listOfQuestionsRef: Reference;
   let defaultPlatform: PlatformRef;
 
   const APP_NAME = 'super-awesome-test-firebase-app-name';

--- a/src/core/angularfire2.ts
+++ b/src/core/angularfire2.ts
@@ -1,4 +1,3 @@
-import * as firebase from 'firebase/app';
 import { FirebaseAppConfigToken, FirebaseApp, _firebaseAppFactory } from './firebase.app.module';
 import { Injectable, InjectionToken, NgModule } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';

--- a/src/core/firebase.app.module.ts
+++ b/src/core/firebase.app.module.ts
@@ -1,18 +1,25 @@
 import { InjectionToken, } from '@angular/core';
 import { FirebaseAppConfig } from './';
-import * as firebase from 'firebase/app';
+import { firebase } from '@firebase/app';
+
+import { FirebaseApp as FBApp } from '@firebase/app-types';
+import { FirebaseAuth } from '@firebase/auth-types';
+import { FirebaseDatabase } from '@firebase/database-types';
+import { FirebaseMessaging } from '@firebase/messaging-types';
+import { FirebaseStorage } from '@firebase/storage-types';
+import { FirebaseFirestore } from '@firebase/firestore-types';
 
 export const FirebaseAppConfigToken = new InjectionToken<FirebaseAppConfig>('FirebaseAppConfigToken');
 
-export class FirebaseApp implements firebase.app.App {
+export class FirebaseApp implements FBApp {
   name: string;
   options: {};
-  auth: () => firebase.auth.Auth;
-  database: () => firebase.database.Database;
-  messaging: () => firebase.messaging.Messaging;
-  storage: () => firebase.storage.Storage;
+  auth: () => FirebaseAuth;
+  database: () => FirebaseDatabase;
+  messaging: () => FirebaseMessaging;
+  storage: () => FirebaseStorage;
   delete: () => Promise<any>;
-  firestore: () => firebase.firestore.Firestore;
+  firestore: () => FirebaseFirestore;
 }
 
 export function _firebaseAppFactory(config: FirebaseAppConfig, appName?: string): FirebaseApp {

--- a/src/core/firebase.app.module.ts
+++ b/src/core/firebase.app.module.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, } from '@angular/core';
 import { FirebaseAppConfig } from './';
-import { firebase } from '@firebase/app';
+import firebase from '@firebase/app';
 
 import { FirebaseApp as FBApp } from '@firebase/app-types';
 import { FirebaseAuth } from '@firebase/auth-types';

--- a/src/database-deprecated/database.module.ts
+++ b/src/database-deprecated/database.module.ts
@@ -1,6 +1,4 @@
 import { NgModule } from '@angular/core';
-import * as firebase from 'firebase/app';
-import 'firebase/database';
 import { AngularFireModule, FirebaseApp } from 'angularfire2';
 import { AngularFireDatabase } from './database';
 

--- a/src/database-deprecated/database.ts
+++ b/src/database-deprecated/database.ts
@@ -1,5 +1,4 @@
-import * as firebase from 'firebase/app';
-import 'firebase/database';
+import { FirebaseDatabase } from '@firebase/database-types';
 import { Inject, Injectable } from '@angular/core';
 import { FirebaseAppConfigToken, FirebaseAppConfig, FirebaseApp } from 'angularfire2';
 import { FirebaseListFactory } from './firebase_list_factory';
@@ -15,8 +14,8 @@ export class AngularFireDatabase {
   /**
    * Firebase Database instance
    */
-  database: firebase.database.Database;
-  
+  database: FirebaseDatabase;
+
   constructor(public app: FirebaseApp) {
     this.database = app.database();
   }

--- a/src/database-deprecated/firebase_list_factory.spec.ts
+++ b/src/database-deprecated/firebase_list_factory.spec.ts
@@ -1,8 +1,8 @@
-import * as firebase from 'firebase/app';
+import { DataSnapshot } from '@firebase/database-types';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule} from 'angularfire2';
-import { AngularFireDatabase, AngularFireDatabaseModule, FirebaseListObservable, 
-  FirebaseListFactory, onChildAdded, onChildChanged, onChildRemoved, onChildUpdated, 
-  FirebaseObjectFactory 
+import { AngularFireDatabase, AngularFireDatabaseModule, FirebaseListObservable,
+  FirebaseListFactory, onChildAdded, onChildChanged, onChildRemoved, onChildUpdated,
+  FirebaseObjectFactory
 } from 'angularfire2/database-deprecated';
 import { TestBed, inject } from '@angular/core/testing';
 import * as utils from './utils';
@@ -652,15 +652,15 @@ describe('FirebaseListFactory', () => {
       };
 
       it('should return an object value with a $key property', () => {
-        const unwrapped = utils.unwrapMapFn(snapshot as firebase.database.DataSnapshot);
+        const unwrapped = utils.unwrapMapFn(snapshot as DataSnapshot);
         expect(unwrapped.$key).toEqual(snapshot.ref.key);
       });
 
       it('should return an object value with a $value property if value is scalar', () => {
         const existsFn = () => { return true; }
-        const unwrappedValue5 = utils.unwrapMapFn(Object.assign(snapshot, { val: () => 5, exists: existsFn }) as firebase.database.DataSnapshot);
-        const unwrappedValueFalse = utils.unwrapMapFn(Object.assign(snapshot, { val: () => false, exists: existsFn }) as firebase.database.DataSnapshot);
-        const unwrappedValueLol = utils.unwrapMapFn(Object.assign(snapshot, { val: () => 'lol', exists: existsFn }) as firebase.database.DataSnapshot);
+        const unwrappedValue5 = utils.unwrapMapFn(Object.assign(snapshot, { val: () => 5, exists: existsFn }) as DataSnapshot);
+        const unwrappedValueFalse = utils.unwrapMapFn(Object.assign(snapshot, { val: () => false, exists: existsFn }) as DataSnapshot);
+        const unwrappedValueLol = utils.unwrapMapFn(Object.assign(snapshot, { val: () => 'lol', exists: existsFn }) as DataSnapshot);
 
         expect(unwrappedValue5.$key).toEqual('key');
         expect(unwrappedValue5.$value).toEqual(5);

--- a/src/database-deprecated/firebase_list_factory.ts
+++ b/src/database-deprecated/firebase_list_factory.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import * as database from '@firebase/database-types';
 import { ZoneScheduler } from 'angularfire2';
 import * as utils from './utils';
 import 'firebase/database';
@@ -92,7 +92,7 @@ export function FirebaseListFactory (
       }
 
       return queried;
-    }), (queryRef: firebase.database.Reference, ix: number) => {
+    }), (queryRef: database.Reference, ix: number) => {
       return firebaseListObservable(queryRef, { preserveSnapshot });
     })
     .subscribe(subscriber);
@@ -108,7 +108,7 @@ export function FirebaseListFactory (
  * asynchonous. It creates a initial array from a promise of ref.once('value'), and then starts
  * listening to child events. When the initial array is loaded, the observable starts emitting values.
  */
-function firebaseListObservable(ref: firebase.database.Reference | DatabaseQuery, {preserveSnapshot}: FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
+function firebaseListObservable(ref: database.Reference | DatabaseQuery, {preserveSnapshot}: FirebaseListFactoryOpts = {}): FirebaseListObservable<any> {
 
   const toValue = preserveSnapshot ? (snapshot => snapshot) : utils.unwrapMapFn;
   const toKey = preserveSnapshot ? (value => value.key) : (value => value.$key);

--- a/src/database-deprecated/firebase_list_factory.ts
+++ b/src/database-deprecated/firebase_list_factory.ts
@@ -1,7 +1,6 @@
 import * as database from '@firebase/database-types';
 import { ZoneScheduler } from 'angularfire2';
 import * as utils from './utils';
-import 'firebase/database';
 import { AFUnwrappedDataSnapshot } from './interfaces';
 import { FirebaseListObservable } from './firebase_list_observable';
 import { Observer } from 'rxjs/Observer';

--- a/src/database-deprecated/firebase_list_observable.spec.ts
+++ b/src/database-deprecated/firebase_list_observable.spec.ts
@@ -2,7 +2,8 @@ import { FirebaseApp, FirebaseAppConfig, AngularFireModule} from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, FirebaseListObservable, FirebaseObjectFactory } from 'angularfire2/database-deprecated';
 import { Observer } from 'rxjs/Observer';
 import { map } from 'rxjs/operator/map';
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
+import { DataSnapshot, Reference } from '@firebase/database-types';
 import { unwrapMapFn } from './utils';
 
 import { TestBed, inject } from '@angular/core/testing';
@@ -10,8 +11,8 @@ import { COMMON_CONFIG } from './test-config';
 
 describe('FirebaseListObservable', () => {
   let O: FirebaseListObservable<any>;
-  let ref: firebase.database.Reference;
-  let app: firebase.app.App;
+  let ref: Reference;
+  let app: FBApp;
   let db: AngularFireDatabase;
 
   beforeEach(() => {
@@ -21,10 +22,10 @@ describe('FirebaseListObservable', () => {
         AngularFireDatabaseModule
       ]
     });
-    inject([FirebaseApp, AngularFireDatabase], (_app: firebase.app.App, _db: AngularFireDatabase) => {
+    inject([FirebaseApp, AngularFireDatabase], (_app: FBApp, _db: AngularFireDatabase) => {
       app = _app;
       db = _db;
-      ref = firebase.database().ref();
+      ref = app.database().ref();
       O = new FirebaseListObservable(ref, (observer:Observer<any>) => {
       });
     })();
@@ -64,7 +65,7 @@ describe('FirebaseListObservable', () => {
 
   describe('remove', () => {
     let orphan = { orphan: true };
-    let child:firebase.database.Reference;
+    let child:Reference;
 
     beforeEach(() => {
       child = ref.push(orphan);
@@ -76,7 +77,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_added', childAddedSpy);
       O.remove(child.key!)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childAddedSpy.calls.argsFor(0)[0].val()).toEqual(orphan);
           expect(data.val()).toBeNull();
           ref.off();
@@ -92,7 +93,7 @@ describe('FirebaseListObservable', () => {
 
       O.remove(child)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childAddedSpy.calls.argsFor(0)[0].val()).toEqual(orphan);
           expect(data.val()).toBeNull();
           ref.off();
@@ -102,11 +103,11 @@ describe('FirebaseListObservable', () => {
 
 
     it('should remove the item from the Firebase db when given the snapshot', (done:any) => {
-      ref.on('child_added', (data:firebase.database.DataSnapshot) => {
+      ref.on('child_added', (data:DataSnapshot) => {
         expect(data.val()).toEqual(orphan);
         O.remove(data)
           .then(() => (<any>ref).once('value'))
-          .then((data:firebase.database.DataSnapshot) => {
+          .then((data:DataSnapshot) => {
             expect(data.val()).toBeNull();
             ref.off();
           })
@@ -116,11 +117,11 @@ describe('FirebaseListObservable', () => {
 
 
     it('should remove the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
-      ref.on('child_added', (data:firebase.database.DataSnapshot) => {
+      ref.on('child_added', (data:DataSnapshot) => {
         expect(data.val()).toEqual(orphan);
         O.remove(unwrapMapFn(data))
           .then(() => (<any>ref).once('value'))
-          .then((data:firebase.database.DataSnapshot) => {
+          .then((data:DataSnapshot) => {
             expect(data.val()).toBeNull();
             ref.off();
           })
@@ -131,7 +132,7 @@ describe('FirebaseListObservable', () => {
     it('should remove the whole list if no item is added', () => {
       O.remove()
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(data.val()).toBe(null);
         });
     });
@@ -146,7 +147,7 @@ describe('FirebaseListObservable', () => {
 
   describe('set', () => {
     let orphan = { orphan: true };
-    let child:firebase.database.Reference;
+    let child:Reference;
 
     beforeEach(() => {
       child = ref.push(orphan);
@@ -158,7 +159,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_changed', childChangedSpy);
       O.set(child.key!, orphanChange)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childChangedSpy.calls.argsFor(0)[0].val()).not.toEqual({
             orphan: true,
             changed: true
@@ -178,7 +179,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_changed', childChangedSpy);
       O.set(child.ref, orphanChange)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childChangedSpy.calls.argsFor(0)[0].val()).not.toEqual({
             orphan: true,
             changed: true
@@ -198,7 +199,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_changed', childChangedSpy);
       O.set(child, orphanChange)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childChangedSpy.calls.argsFor(0)[0].val()).not.toEqual({
             orphan: true,
             changed: true
@@ -214,11 +215,11 @@ describe('FirebaseListObservable', () => {
 
     it('should set(replace) the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
       const orphanChange = { changed: true }
-      ref.on('child_added', (data:firebase.database.DataSnapshot) => {
+      ref.on('child_added', (data:DataSnapshot) => {
         expect(data.val()).toEqual(orphan);
         O.set(unwrapMapFn(data), orphanChange)
           .then(() => (<any>child).once('value'))
-          .then((data:firebase.database.DataSnapshot) => {
+          .then((data:DataSnapshot) => {
             expect(data.val()).not.toEqual({
               orphan: true,
               changed: true
@@ -238,7 +239,7 @@ describe('FirebaseListObservable', () => {
 
   describe('update', () => {
     let orphan = { orphan: true };
-    let child:firebase.database.Reference;
+    let child:Reference;
 
     beforeEach(() => {
       child = ref.push(orphan);
@@ -250,7 +251,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_changed', childChangedSpy);
       O.update(child.key!, orphanChange)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({
             orphan: true,
             changed: true
@@ -267,7 +268,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_changed', childChangedSpy);
       O.update(child.ref, orphanChange)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({
             orphan: true,
             changed: true
@@ -284,7 +285,7 @@ describe('FirebaseListObservable', () => {
       ref.on('child_changed', childChangedSpy);
       O.update(child, orphanChange)
         .then(() => (<any>ref).once('value'))
-        .then((data:firebase.database.DataSnapshot) => {
+        .then((data:DataSnapshot) => {
           expect(childChangedSpy.calls.argsFor(0)[0].val()).toEqual({
             orphan: true,
             changed: true
@@ -297,11 +298,11 @@ describe('FirebaseListObservable', () => {
 
     it('should update the item from the Firebase db when given the unwrapped snapshot', (done:any) => {
       const orphanChange = { changed: true }
-      ref.on('child_added', (data:firebase.database.DataSnapshot) => {
+      ref.on('child_added', (data:DataSnapshot) => {
         expect(data.val()).toEqual(orphan);
         O.update(unwrapMapFn(data), orphanChange)
           .then(() => (<any>child).once('value'))
-          .then((data:firebase.database.DataSnapshot) => {
+          .then((data:DataSnapshot) => {
             expect(data.val()).toEqual({
               orphan: true,
               changed: true

--- a/src/database-deprecated/firebase_list_observable.ts
+++ b/src/database-deprecated/firebase_list_observable.ts
@@ -2,12 +2,11 @@ import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
-import * as firebase from 'firebase/app';
-import 'firebase/database';
+import { Reference, DataSnapshot, ThenableReference } from '@firebase/database-types';
 import * as utils from './utils';
 import { AFUnwrappedDataSnapshot, FirebaseOperationCases, QueryReference, DatabaseSnapshot, DatabaseReference } from './interfaces';
 
-export type FirebaseOperation = string | firebase.database.Reference | firebase.database.DataSnapshot | AFUnwrappedDataSnapshot;
+export type FirebaseOperation = string | Reference | DataSnapshot | AFUnwrappedDataSnapshot;
 
 export class FirebaseListObservable<T> extends Observable<T> {
   constructor(public $ref: QueryReference, subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
@@ -21,7 +20,7 @@ export class FirebaseListObservable<T> extends Observable<T> {
     return observable;
   }
 
-  push(val:any):firebase.database.ThenableReference {
+  push(val:any):ThenableReference {
     if(!this.$ref) {
       throw new Error('No ref specified for this Observable!');
     }
@@ -31,8 +30,8 @@ export class FirebaseListObservable<T> extends Observable<T> {
   set(item: FirebaseOperation, value: Object): Promise<void> {
     return this._checkOperationCases(item, {
       stringCase: () => this.$ref.ref.child(<string>item).set(value),
-      firebaseCase: () => (<firebase.database.Reference>item).set(value),
-      snapshotCase: () => (<firebase.database.DataSnapshot>item).ref.set(value),
+      firebaseCase: () => (<Reference>item).set(value),
+      snapshotCase: () => (<DataSnapshot>item).ref.set(value),
       unwrappedSnapshotCase: () => this.$ref.ref.child((<AFUnwrappedDataSnapshot>item).$key).set(value)
     });
   }
@@ -40,8 +39,8 @@ export class FirebaseListObservable<T> extends Observable<T> {
   update(item: FirebaseOperation, value: Object): Promise<void> {
     return this._checkOperationCases(item, {
       stringCase: () => this.$ref.ref.child(<string>item).update(value),
-      firebaseCase: () => (<firebase.database.Reference>item).update(value),
-      snapshotCase: () => (<firebase.database.DataSnapshot>item).ref.update(value),
+      firebaseCase: () => (<Reference>item).update(value),
+      snapshotCase: () => (<DataSnapshot>item).ref.update(value),
       unwrappedSnapshotCase: () => this.$ref.ref.child((<AFUnwrappedDataSnapshot>item).$key).update(value)
     });
   }

--- a/src/database-deprecated/firebase_object_factory.spec.ts
+++ b/src/database-deprecated/firebase_object_factory.spec.ts
@@ -1,4 +1,5 @@
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
+import { Reference } from '@firebase/database-types';
 import { Subscription } from 'rxjs';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, FirebaseObjectObservable, FirebaseObjectFactory } from 'angularfire2/database-deprecated';
@@ -7,13 +8,13 @@ import { COMMON_CONFIG } from './test-config';
 
 describe('FirebaseObjectFactory', () => {
   let i = 0;
-  let ref: firebase.database.Reference;
+  let ref: Reference;
   let observable: FirebaseObjectObservable<any>;
   let subscription: Subscription;
   let nextSpy: jasmine.Spy;
-  let app: firebase.app.App;
+  let app: FBApp;
   let db: AngularFireDatabase;
-  
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [

--- a/src/database-deprecated/firebase_object_factory.ts
+++ b/src/database-deprecated/firebase_object_factory.ts
@@ -2,8 +2,7 @@ import { FirebaseObjectObservable } from './firebase_object_observable';
 import { ZoneScheduler } from 'angularfire2';
 import { Observer } from 'rxjs/Observer';
 import { observeOn } from 'rxjs/operator/observeOn';
-import * as firebase from 'firebase/app';
-import 'firebase/database';
+import { DataSnapshot } from '@firebase/database-types';
 import * as utils from './utils';
 import { FirebaseObjectFactoryOpts, DatabaseReference } from './interfaces';
 
@@ -12,7 +11,7 @@ export function FirebaseObjectFactory (
   { preserveSnapshot }: FirebaseObjectFactoryOpts = {}): FirebaseObjectObservable<any> {
 
   const objectObservable = new FirebaseObjectObservable((obs: Observer<any>) => {
-    let fn = ref.on('value', (snapshot: firebase.database.DataSnapshot) => {
+    let fn = ref.on('value', (snapshot: DataSnapshot) => {
       obs.next(preserveSnapshot ? snapshot : utils.unwrapMapFn(snapshot))
     }, err => {
       if (err) { obs.error(err); obs.complete(); }

--- a/src/database-deprecated/firebase_object_observable.spec.ts
+++ b/src/database-deprecated/firebase_object_observable.spec.ts
@@ -4,13 +4,14 @@ import { COMMON_CONFIG } from './test-config';
 import { AngularFireDatabase, AngularFireDatabaseModule, FirebaseObjectObservable } from 'angularfire2/database-deprecated';
 import { Observer } from 'rxjs/Observer';
 import { map } from 'rxjs/operator/map';
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
+import { Reference } from '@firebase/database-types';
 
 describe('FirebaseObjectObservable', () => {
 
   let O: FirebaseObjectObservable<any>;
-  let ref: firebase.database.Reference;
-  let app: firebase.app.App;
+  let ref: Reference;
+  let app: FBApp;
   let db: AngularFireDatabase;
 
   beforeEach(() => {
@@ -20,10 +21,10 @@ describe('FirebaseObjectObservable', () => {
         AngularFireDatabaseModule
       ]
     });
-    inject([FirebaseApp, AngularFireDatabase], (_app: firebase.app.App, _db: AngularFireDatabase) => {
+    inject([FirebaseApp, AngularFireDatabase], (_app: FBApp, _db: AngularFireDatabase) => {
       app = _app;
       db = _db;
-      ref = firebase.database().ref();
+      ref = app.database().ref();
       O = new FirebaseObjectObservable((observer: Observer<any>) => {
       }, ref);
     })();

--- a/src/database-deprecated/firebase_object_observable.ts
+++ b/src/database-deprecated/firebase_object_observable.ts
@@ -2,11 +2,10 @@ import { Observable } from 'rxjs/Observable';
 import { Operator } from 'rxjs/Operator';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
-import * as firebase from 'firebase/app';
-import 'firebase/database';
+import { Reference } from '@firebase/database-types';
 
 export class FirebaseObjectObservable<T> extends Observable<T> {
-  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, public $ref?:firebase.database.Reference) {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void, public $ref?:Reference) {
     super(subscribe);
   }
   lift<T, R>(operator: Operator<T, R>): Observable<R> {

--- a/src/database-deprecated/interfaces.ts
+++ b/src/database-deprecated/interfaces.ts
@@ -1,5 +1,5 @@
-import * as firebase from 'firebase/app';
 import { Observable } from 'rxjs/Observable';
+import { Reference, DataSnapshot, Query } from '@firebase/database-types';
 
 export interface FirebaseOperationCases {
   stringCase: () => Promise<void>;
@@ -81,8 +81,8 @@ export enum QueryOptions {
 
 export type Primitive = number | string | boolean;
 
-export type DatabaseSnapshot = firebase.database.DataSnapshot;
-export type DatabaseReference = firebase.database.Reference;
-export type DatabaseQuery = firebase.database.Query;
+export type DatabaseSnapshot = DataSnapshot;
+export type DatabaseReference = Reference;
+export type DatabaseQuery = Query;
 export type QueryReference = DatabaseReference | DatabaseQuery;
 export type PathReference = QueryReference | string;

--- a/src/database-deprecated/utils.ts
+++ b/src/database-deprecated/utils.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { DataSnapshot } from '@firebase/database-types';
 import { Subscription } from 'rxjs/Subscription';
 import { Scheduler } from 'rxjs/Scheduler';
 import { queue } from 'rxjs/scheduler/queue';
@@ -53,7 +53,7 @@ export interface CheckUrlRef {
  * @example
  * unwrapMapFn(snapshot) => { name: 'David', $key: 'david', $exists: Function }
  */
-export function unwrapMapFn (snapshot:firebase.database.DataSnapshot): AFUnwrappedDataSnapshot {
+export function unwrapMapFn (snapshot:DataSnapshot): AFUnwrappedDataSnapshot {
   var unwrapped = !isNil(snapshot.val()) ? snapshot.val() : { $value: null };
   if ((/string|number|boolean/).test(typeof unwrapped)) {
     unwrapped = {

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,6 +1,4 @@
 import { NgModule } from '@angular/core';
-import * as firebase from 'firebase/app';
-import 'firebase/database';
 import { AngularFireModule, FirebaseApp } from 'angularfire2';
 import { AngularFireDatabase } from './database';
 

--- a/src/database/database.spec.ts
+++ b/src/database/database.spec.ts
@@ -1,4 +1,3 @@
-import * as firebase from 'firebase/app';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule} from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule } from 'angularfire2/database';
 import { TestBed, inject } from '@angular/core/testing';
@@ -45,7 +44,7 @@ describe('AngularFireDatabase', () => {
 
     it('should have an initialized Firebase database instance member', () => {
       expect(db.database.app.name).toEqual(FIREBASE_APP_NAME);
-    });    
+    });
   });
 
 });

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { database } from 'firebase/app';
-import 'firebase/database';
+import { FirebaseDatabase } from '@firebase/database-types';
 import { FirebaseApp } from 'angularfire2';
 import { PathReference, DatabaseQuery, DatabaseReference, DatabaseSnapshot, ChildEvent, ListenEvent, QueryFn, AngularFireList, AngularFireObject } from './interfaces';
 import { getRef } from './utils';
@@ -9,7 +8,7 @@ import { createObjectReference } from './object/create-reference';
 
 @Injectable()
 export class AngularFireDatabase {
-  database: database.Database;
+  database: FirebaseDatabase;
 
   constructor(public app: FirebaseApp) {
     this.database = app.database();
@@ -26,7 +25,7 @@ export class AngularFireDatabase {
 
   object<T>(pathOrRef: PathReference): AngularFireObject<T>  {
     const ref = getRef(this.app, pathOrRef);
-    return createObjectReference<T>(ref);    
+    return createObjectReference<T>(ref);
   }
 
   createPushId() {
@@ -35,18 +34,17 @@ export class AngularFireDatabase {
 
 }
 
-export { 
-  PathReference, 
-  DatabaseQuery, 
-  DatabaseReference, 
-  DatabaseSnapshot, 
-  ChildEvent, 
-  ListenEvent, 
-  QueryFn, 
-  AngularFireList, 
+export {
+  PathReference,
+  DatabaseQuery,
+  DatabaseReference,
+  DatabaseSnapshot,
+  ChildEvent,
+  ListenEvent,
+  QueryFn,
+  AngularFireList,
   AngularFireObject,
   AngularFireAction,
   Action,
   SnapshotAction
 } from './interfaces';
- 

--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -1,7 +1,7 @@
-import * as firebase from 'firebase/app';
+import { Reference, DataSnapshot, ThenableReference, Query } from '@firebase/database-types';
 import { Observable } from 'rxjs/Observable';
 
-export type FirebaseOperation = string | firebase.database.Reference | firebase.database.DataSnapshot;
+export type FirebaseOperation = string | Reference | DataSnapshot;
 
 export interface AngularFireList<T> {
   query: DatabaseQuery;
@@ -11,7 +11,7 @@ export interface AngularFireList<T> {
   auditTrail(events?: ChildEvent[]): Observable<SnapshotAction[]>;
   update(item: FirebaseOperation, data: T): Promise<void>;
   set(item: FirebaseOperation, data: T): Promise<void>;
-  push(data: T): firebase.database.ThenableReference;
+  push(data: T): ThenableReference;
   remove(item?: FirebaseOperation): Promise<void>;
 }
 
@@ -49,8 +49,8 @@ export type SnapshotAction = AngularFireAction<DatabaseSnapshot>;
 
 export type Primitive = number | string | boolean;
 
-export type DatabaseSnapshot = firebase.database.DataSnapshot;
-export type DatabaseReference = firebase.database.Reference;
-export type DatabaseQuery = firebase.database.Query;
+export type DatabaseSnapshot = DataSnapshot;
+export type DatabaseReference = Reference;
+export type DatabaseQuery = Query;
 export type QueryReference = DatabaseReference | DatabaseQuery;
 export type PathReference = QueryReference | string;

--- a/src/database/list/audit-trail.spec.ts
+++ b/src/database/list/audit-trail.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { Reference } from '@firebase/database-types';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, auditTrail, ChildEvent } from 'angularfire2/database';
 import { TestBed, inject } from '@angular/core/testing';
@@ -12,7 +12,7 @@ const FIREBASE_APP_NAME = rando();
 describe('auditTrail', () => {
   let app: FirebaseApp;
   let db: AngularFireDatabase;
-  let createRef: (path: string) => firebase.database.Reference;
+  let createRef: (path: string) => Reference;
   let batch = {};
   const items = [{ name: 'zero' }, { name: 'one' }, { name: 'two' }].map((item, i) => ( { key: i.toString(), ...item } ));
   Object.keys(items).forEach(function (key, i) {
@@ -48,7 +48,7 @@ describe('auditTrail', () => {
     const changes = auditTrail(aref, events);
     return {
       changes: changes.skip(skip),
-      ref: aref 
+      ref: aref
     };
   }
 

--- a/src/database/list/audit-trail.ts
+++ b/src/database/list/audit-trail.ts
@@ -1,7 +1,7 @@
 import { DatabaseQuery, ChildEvent, DatabaseSnapshot, AngularFireAction, SnapshotAction } from '../interfaces';
 import { stateChanges } from './state-changes';
 import { Observable } from 'rxjs/Observable';
-import { database } from 'firebase/app';
+import { DataSnapshot } from '@firebase/database-types';
 import { fromRef } from '../observable/fromRef';
 
 
@@ -20,7 +20,7 @@ export function auditTrail(query: DatabaseQuery, events?: ChildEvent[]): Observa
 }
 
 interface LoadedMetadata {
-  data: AngularFireAction<database.DataSnapshot>;
+  data: AngularFireAction<DataSnapshot>;
   lastKeyToLoad: any;
 }
 
@@ -60,5 +60,5 @@ function waitForLoaded(query: DatabaseQuery, action$: Observable<SnapshotAction[
     .skipWhile(meta => meta.loadedKeys.indexOf(meta.lastKeyToLoad) === -1)
     // Pluck off the meta data because the user only cares
     // to iterate through the snapshots
-    .map(meta => meta.actions);  
+    .map(meta => meta.actions);
 }

--- a/src/database/list/changes.spec.ts
+++ b/src/database/list/changes.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { Reference } from '@firebase/database-types';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, listChanges } from 'angularfire2/database';
 import { TestBed, inject } from '@angular/core/testing';
@@ -12,7 +12,7 @@ const FIREBASE_APP_NAME = rando();
 describe('listChanges', () => {
   let app: FirebaseApp;
   let db: AngularFireDatabase;
-  let ref: (path: string) => firebase.database.Reference;
+  let ref: (path: string) => Reference;
   let batch = {};
   const items = [{ name: 'zero' }, { name: 'one' }, { name: 'two' }].map((item, i) => ( { key: i.toString(), ...item } ));
   Object.keys(items).forEach(function (key, i) {
@@ -42,7 +42,7 @@ describe('listChanges', () => {
   });
 
   describe('events', () => {
-    
+
     it('should stream value at first', (done) => {
       const someRef = ref(rando());
       const obs = listChanges(someRef, ['child_added']);
@@ -141,8 +141,8 @@ describe('listChanges', () => {
       aref.set(batch).then(() => {
         aref.child(items[0].key).setPriority('a', () => {});
       });
-    });    
-    
+    });
+
   });
 
 });

--- a/src/database/list/remove.ts
+++ b/src/database/list/remove.ts
@@ -1,7 +1,7 @@
 import { DatabaseReference, FirebaseOperation, DatabaseSnapshot } from '../interfaces';
 import { checkOperationCases } from '../utils';
 import { createDataOperationMethod } from './data-operation';
-import { database } from 'firebase/app';
+import { DataSnapshot, Reference } from '@firebase/database-types';
 
 // TODO(davideast): Find out why TS thinks this returns firebase.Primise
 // instead of Promise.

--- a/src/database/list/snapshot-changes.spec.ts
+++ b/src/database/list/snapshot-changes.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { Reference } from '@firebase/database-types';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, snapshotChanges, ChildEvent } from 'angularfire2/database';
 import { TestBed, inject } from '@angular/core/testing';
@@ -13,7 +13,7 @@ const FIREBASE_APP_NAME = rando();
 describe('snapshotChanges', () => {
   let app: FirebaseApp;
   let db: AngularFireDatabase;
-  let createRef: (path: string) => firebase.database.Reference;
+  let createRef: (path: string) => Reference;
   let batch = {};
   const items = [{ name: 'zero' }, { name: 'one' }, { name: 'two' }].map((item, i) => ( { key: i.toString(), ...item } ));
   Object.keys(items).forEach(function (key, i) {
@@ -48,7 +48,7 @@ describe('snapshotChanges', () => {
     const snapChanges = snapshotChanges(aref, events);
     return {
       snapChanges: snapChanges.skip(skip),
-      ref: aref 
+      ref: aref
     };
   }
 
@@ -92,8 +92,8 @@ describe('snapshotChanges', () => {
   });
 
   it('should listen to only child_added, child_changed events', (done) => {
-    const { snapChanges, ref } = prepareSnapshotChanges({ 
-      events: ['child_added', 'child_changed'], 
+    const { snapChanges, ref } = prepareSnapshotChanges({
+      events: ['child_added', 'child_changed'],
       skip: 1
     });
     const name = 'ligatures';
@@ -108,7 +108,7 @@ describe('snapshotChanges', () => {
       ref.child(items[0].key).update({ name })
     });
   });
-  
+
   it('should handle empty sets', done => {
     const aref = createRef(rando());
     aref.set({});

--- a/src/database/list/snapshot-changes.ts
+++ b/src/database/list/snapshot-changes.ts
@@ -1,7 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 import { listChanges } from './changes';
 import { DatabaseQuery, ChildEvent, SnapshotAction } from '../interfaces';
-import { database } from 'firebase/app';
 import { validateEventsArray } from './utils';
 import 'rxjs/add/operator/map';
 

--- a/src/database/list/state-changes.spec.ts
+++ b/src/database/list/state-changes.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { Reference } from '@firebase/database-types';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, stateChanges, ChildEvent } from 'angularfire2/database';
 import { TestBed, inject } from '@angular/core/testing';
@@ -12,7 +12,7 @@ const FIREBASE_APP_NAME = rando();
 describe('stateChanges', () => {
   let app: FirebaseApp;
   let db: AngularFireDatabase;
-  let createRef: (path: string) => firebase.database.Reference;
+  let createRef: (path: string) => Reference;
   let batch = {};
   const items = [{ name: 'zero' }, { name: 'one' }, { name: 'two' }].map((item, i) => ( { key: i.toString(), ...item } ));
   Object.keys(items).forEach(function (key, i) {
@@ -48,7 +48,7 @@ describe('stateChanges', () => {
     const changes = stateChanges(aref, events);
     return {
       changes: changes.skip(skip),
-      ref: aref 
+      ref: aref
     };
   }
 

--- a/src/database/list/state-changes.ts
+++ b/src/database/list/state-changes.ts
@@ -2,9 +2,9 @@ import { DatabaseQuery, ChildEvent, AngularFireAction, SnapshotAction } from '..
 import { fromRef } from '../observable/fromRef';
 import { validateEventsArray } from './utils';
 import { Observable } from 'rxjs/Observable';
-import { database } from 'firebase/app';
 import 'rxjs/add/observable/merge';
 import 'rxjs/add/operator/scan';
+import { DataSnapshot } from '@firebase/database-types';
 
 export function createStateChanges(query: DatabaseQuery) {
   return (events?: ChildEvent[]) => stateChanges(query, events);

--- a/src/database/object/snapshot-changes.ts
+++ b/src/database/object/snapshot-changes.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs/Observable';
 import { fromRef } from '../observable/fromRef';
 import { DatabaseQuery, AngularFireAction, SnapshotAction } from '../interfaces';
-import { database } from 'firebase/app';
+import { DataSnapshot } from '@firebase/database-types';
 
 export function createObjectSnapshotChanges(query: DatabaseQuery) {
   return function snapshotChanges(): Observable<SnapshotAction> {

--- a/src/database/observable/fromRef.spec.ts
+++ b/src/database/observable/fromRef.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { Reference } from '@firebase/database-types';
 import { FirebaseApp, FirebaseAppConfig, AngularFireModule } from 'angularfire2';
 import { AngularFireDatabase, AngularFireDatabaseModule, fromRef } from 'angularfire2/database';
 import { TestBed, inject } from '@angular/core/testing';
@@ -10,7 +10,7 @@ const FIREBASE_APP_NAME = rando();
 
 describe('fromRef', () => {
   let app: FirebaseApp;
-  let ref: (path: string) => firebase.database.Reference;
+  let ref: (path: string) => Reference;
   let batch = {};
   const items = [{ name: 'one' }, { name: 'two' }, { name: 'three' }].map(item => ( { key: rando(), ...item } ));
   Object.keys(items).forEach(function (key) {
@@ -122,7 +122,7 @@ describe('fromRef', () => {
       });
       itemRef.child(key).update({ name });
     });
-    
+
     it('should stream back a child_removed event', async (done: any) => {
       const itemRef = ref(rando());
       itemRef.set(batch);
@@ -139,7 +139,7 @@ describe('fromRef', () => {
       });
       itemRef.child(key).remove();
     });
-    
+
     it('should stream back a child_moved event', async (done: any) => {
       const itemRef = ref(rando());
       itemRef.set(batch);
@@ -155,7 +155,7 @@ describe('fromRef', () => {
         done();
       });
       itemRef.child(key).setPriority(-100, () => {});
-    });    
+    });
 
     it('should stream back a value event', (done: any) => {
       const itemRef = ref(rando());
@@ -169,7 +169,7 @@ describe('fromRef', () => {
         sub.unsubscribe();
         expect(sub.closed).toEqual(true);
       });
-    });  
+    });
 
     it('should stream back query results', (done: any) => {
       const itemRef = ref(rando());
@@ -183,7 +183,7 @@ describe('fromRef', () => {
         done();
       });
     });
-    
+
   });
 
 });

--- a/src/database/utils.spec.ts
+++ b/src/database/utils.spec.ts
@@ -1,4 +1,3 @@
-import * as firebase from 'firebase/app';
 import { TestBed, inject } from '@angular/core/testing';
 import * as utils from './utils';
 

--- a/src/database/utils.ts
+++ b/src/database/utils.ts
@@ -1,4 +1,3 @@
-import * as firebase from 'firebase/app';
 import { Subscription } from 'rxjs/Subscription';
 import { Scheduler } from 'rxjs/Scheduler';
 import { queue } from 'rxjs/scheduler/queue';
@@ -29,7 +28,7 @@ export function isFirebaseRef(value: any): boolean {
  */
 export function getRef(app: FirebaseApp, pathRef: PathReference): DatabaseReference {
   // if a db ref was passed in, just return it
-  return isFirebaseRef(pathRef) ? pathRef as DatabaseReference 
+  return isFirebaseRef(pathRef) ? pathRef as DatabaseReference
     : app.database().ref(pathRef as string);
 }
 

--- a/src/firestore/collection/changes.ts
+++ b/src/firestore/collection/changes.ts
@@ -1,6 +1,5 @@
 import { fromCollectionRef } from '../observable/fromRef';
-import * as firebase from 'firebase/app';
-import 'firebase/firestore';
+import { Query, DocumentChangeType, DocumentChange } from '@firebase/firestore-types';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/filter';
@@ -10,21 +9,21 @@ import { DocumentChangeAction, Action } from '../interfaces';
 
 /**
  * Return a stream of document changes on a query. These results are not in sort order but in
- * order of occurence. 
- * @param query 
+ * order of occurence.
+ * @param query
  */
-export function docChanges(query: firebase.firestore.Query): Observable<DocumentChangeAction[]> {
+export function docChanges(query: Query): Observable<DocumentChangeAction[]> {
   return fromCollectionRef(query)
-    .map(action => 
+    .map(action =>
       action.payload.docChanges
         .map(change => ({ type: change.type, payload: change })));
 }
 
 /**
  * Return a stream of document changes on a query. These results are in sort order.
- * @param query 
+ * @param query
  */
-export function sortedChanges(query: firebase.firestore.Query, events: firebase.firestore.DocumentChangeType[]): Observable<DocumentChangeAction[]> {
+export function sortedChanges(query: Query, events: DocumentChangeType[]): Observable<DocumentChangeAction[]> {
   return fromCollectionRef(query)
     .map(changes => changes.payload.docChanges)
     .scan((current, changes) => combineChanges(current, changes, events), [])
@@ -34,11 +33,11 @@ export function sortedChanges(query: firebase.firestore.Query, events: firebase.
 /**
  * Combines the total result set from the current set of changes from an incoming set
  * of changes.
- * @param current 
- * @param changes 
+ * @param current
+ * @param changes
  * @param events
  */
-export function combineChanges(current: firebase.firestore.DocumentChange[], changes: firebase.firestore.DocumentChange[], events: firebase.firestore.DocumentChangeType[]) {
+export function combineChanges(current: DocumentChange[], changes: DocumentChange[], events: DocumentChangeType[]) {
   changes.forEach(change => {
     // skip unwanted change types
     if(events.indexOf(change.type) > -1) {
@@ -50,10 +49,10 @@ export function combineChanges(current: firebase.firestore.DocumentChange[], cha
 
 /**
  * Creates a new sorted array from a new change.
- * @param combined 
- * @param change 
+ * @param combined
+ * @param change
  */
-export function combineChange(combined: firebase.firestore.DocumentChange[], change: firebase.firestore.DocumentChange): firebase.firestore.DocumentChange[] {
+export function combineChange(combined: DocumentChange[], change: DocumentChange): DocumentChange[] {
   switch(change.type) {
     case 'added':
       if (combined[change.newIndex] && combined[change.newIndex].doc.id == change.doc.id) {

--- a/src/firestore/document/document.spec.ts
+++ b/src/firestore/document/document.spec.ts
@@ -3,7 +3,7 @@ import { AngularFirestore } from '../firestore';
 import { AngularFirestoreModule } from '../firestore.module';
 import { AngularFirestoreDocument } from '../document/document';
 
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -13,7 +13,7 @@ import { COMMON_CONFIG } from '../test-config';
 import { Stock, randomName, FAKE_STOCK_DATA } from '../utils.spec';
 
 describe('AngularFirestoreDocument', () => {
-  let app: firebase.app.App;
+  let app: FBApp;
   let afs: AngularFirestore;
   let sub: Subscription;
 
@@ -24,7 +24,7 @@ describe('AngularFirestoreDocument', () => {
         AngularFirestoreModule.enablePersistence()
       ]
     });
-    inject([FirebaseApp, AngularFirestore], (_app: firebase.app.App, _afs: AngularFirestore) => {
+    inject([FirebaseApp, AngularFirestore], (_app: FBApp, _afs: AngularFirestore) => {
       app = _app;
       afs = _afs;
     })();

--- a/src/firestore/document/document.ts
+++ b/src/firestore/document/document.ts
@@ -1,5 +1,4 @@
-import * as firebase from 'firebase/app';
-import 'firebase/firestore';
+import { DocumentReference, SetOptions, DocumentSnapshot } from '@firebase/firestore-types';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { QueryFn, AssociatedReference, Action } from '../interfaces';
@@ -26,7 +25,7 @@ import { AngularFirestoreCollection } from '../collection/collection';
  *
  * Example:
  *
- * const fakeStock = new AngularFirestoreDocument<Stock>(firebase.firestore.doc('stocks/FAKE'));
+ * const fakeStock = new AngularFirestoreDocument<Stock>(doc('stocks/FAKE'));
  * await fakeStock.set({ name: 'FAKE', price: 0.01 });
  * fakeStock.valueChanges().map(snap => {
  *   if(snap.exists) return snap.data();
@@ -42,14 +41,14 @@ export class AngularFirestoreDocument<T> {
    * for data operations, data streaming, and Symbol.observable.
    * @param ref
    */
-  constructor(public ref: firebase.firestore.DocumentReference) { }
+  constructor(public ref: DocumentReference) { }
 
   /**
    * Create or overwrite a single document.
    * @param data
    * @param options
    */
-  set(data: T, options?: firebase.firestore.SetOptions): Promise<void> {
+  set(data: T, options?: SetOptions): Promise<void> {
     return this.ref.set(data, options);
   }
 
@@ -83,7 +82,7 @@ export class AngularFirestoreDocument<T> {
   /**
    * Listen to snapshot updates from the document.
    */
-  snapshotChanges(): Observable<Action<firebase.firestore.DocumentSnapshot>> {
+  snapshotChanges(): Observable<Action<DocumentSnapshot>> {
     return fromDocRef(this.ref);
   }
 

--- a/src/firestore/firestore.spec.ts
+++ b/src/firestore/firestore.spec.ts
@@ -4,7 +4,7 @@ import { AngularFirestoreModule } from './firestore.module';
 import { AngularFirestoreDocument } from './document/document';
 import { AngularFirestoreCollection } from './collection/collection';
 
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
@@ -17,7 +17,7 @@ interface Stock {
 }
 
 describe('AngularFirestore', () => {
-  let app: firebase.app.App;
+  let app: FBApp;
   let afs: AngularFirestore;
   let sub: Subscription;
 
@@ -28,7 +28,7 @@ describe('AngularFirestore', () => {
         AngularFirestoreModule.enablePersistence()
       ]
     });
-    inject([FirebaseApp, AngularFirestore], (_app: firebase.app.App, _afs: AngularFirestore) => {
+    inject([FirebaseApp, AngularFirestore], (_app: FBApp, _afs: AngularFirestore) => {
       app = _app;
       afs = _afs;
     })();
@@ -62,14 +62,14 @@ describe('AngularFirestore', () => {
     const tripleWrapper = () => afs.doc('collection/doc/subcollection');
     expect(singleWrapper).toThrowError();
     expect(tripleWrapper).toThrowError();
-  });    
+  });
 
   it('should throw on an invalid collection path', () => {
     const singleWrapper = () => afs.collection('collection/doc');
     const quadWrapper = () => afs.collection('collection/doc/subcollection/doc');
     expect(singleWrapper).toThrowError();
     expect(quadWrapper).toThrowError();
-  }); 
+  });
 
   it('should enable persistence', (done) => {
     const sub = afs.persistenceEnabled$.subscribe(isEnabled => {

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -1,5 +1,4 @@
-import * as firebase from 'firebase/app';
-import 'firebase/firestore';
+import { FirebaseFirestore, CollectionReference } from '@firebase/firestore-types';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { from } from 'rxjs/observable/from';
@@ -16,16 +15,16 @@ import { AngularFirestoreCollection } from './collection/collection';
 /**
  * A utility methods for associating a collection reference with
  * a query.
- * 
+ *
  * @param collectionRef - A collection reference to query
  * @param queryFn - The callback to create a query
- * 
+ *
  * Example:
  * const { query, ref } = associateQuery(docRef.collection('items'), ref => {
  *  return ref.where('age', '<', 200);
  * });
  */
-export function associateQuery(collectionRef: firebase.firestore.CollectionReference, queryFn = ref => ref): AssociatedReference {
+export function associateQuery(collectionRef: CollectionReference, queryFn = ref => ref): AssociatedReference {
   const query = queryFn(collectionRef);
   const ref = collectionRef;
   return { query, ref };
@@ -33,18 +32,18 @@ export function associateQuery(collectionRef: firebase.firestore.CollectionRefer
 
 /**
  * AngularFirestore Service
- * 
+ *
  * This service is the main entry point for this feature module. It provides
  * an API for creating Collection and Reference services. These services can
  * then be used to do data updates and observable streams of the data.
- * 
+ *
  * Example:
- * 
+ *
  * import { Component } from '@angular/core';
  * import { AngularFirestore, AngularFirestoreCollection, AngularFirestoreDocument } from 'angularfire2/firestore';
  * import { Observable } from 'rxjs/Observable';
  * import { from } from 'rxjs/observable/from';
- * 
+ *
  * @Component({
  *   selector: 'app-my-component',
  *   template: `
@@ -59,27 +58,27 @@ export function associateQuery(collectionRef: firebase.firestore.CollectionRefer
  *   `
  * })
  * export class MyComponent implements OnInit {
- *   
+ *
  *   // services for data operations and data streaming
  *   private readonly itemsRef: AngularFirestoreCollection<Item>;
  *   private readonly profileRef: AngularFirestoreDocument<Profile>;
- * 
+ *
  *   // observables for template
  *   items: Observable<Item[]>;
  *   profile: Observable<Profile>;
- * 
+ *
  *   // inject main service
  *   constructor(private readonly afs: AngularFirestore) {}
- * 
+ *
  *   ngOnInit() {
  *     this.itemsRef = afs.collection('items', ref => ref.where('user', '==', 'davideast').limit(10));
  *     this.items = this.itemsRef.valueChanges().map(snap => snap.docs.map(data => doc.data()));
  *     // this.items = from(this.itemsRef); // you can also do this with no mapping
- *     
+ *
  *     this.profileRef = afs.doc('users/davideast');
  *     this.profile = this.profileRef.valueChanges();
  *   }
- * 
+ *
  *   addItem(name: string) {
  *     const user = 'davideast';
  *     this.itemsRef.add({ name, user });
@@ -88,14 +87,14 @@ export function associateQuery(collectionRef: firebase.firestore.CollectionRefer
  */
 @Injectable()
 export class AngularFirestore {
-  public readonly firestore: firebase.firestore.Firestore;
+  public readonly firestore: FirebaseFirestore;
   public readonly persistenceEnabled$: Observable<boolean>;
 
   /**
    * Each Feature of AngularFire has a FirebaseApp injected. This way we
    * don't rely on the main Firebase App instance and we can create named
    * apps and use multiple apps.
-   * @param app 
+   * @param app
    */
   constructor(public app: FirebaseApp, shouldEnablePersistence) {
     this.firestore = app.firestore();
@@ -104,12 +103,12 @@ export class AngularFirestore {
       from(app.firestore().enablePersistence().then(() => true, () => false)) :
       from(new Promise((res, rej) => { res(false); }));
   }
-  
+
   /**
    * Create a reference to a Firestore Collection based on a path and an optional
    * query function to narrow the result set.
-   * @param path 
-   * @param queryFn 
+   * @param path
+   * @param queryFn
    */
   collection<T>(path: string, queryFn?: QueryFn): AngularFirestoreCollection<T> {
     const collectionRef = this.firestore.collection(path);
@@ -119,9 +118,9 @@ export class AngularFirestore {
 
   /**
    * Create a reference to a Firestore Document based on a path. Note that documents
-   * are not queryable because they are simply objects. However, documents have 
+   * are not queryable because they are simply objects. However, documents have
    * sub-collections that return a Collection reference and can be queried.
-   * @param path 
+   * @param path
    */
   doc<T>(path: string): AngularFirestoreDocument<T> {
     const ref = this.firestore.doc(path);

--- a/src/firestore/interfaces.ts
+++ b/src/firestore/interfaces.ts
@@ -1,9 +1,9 @@
 import { Subscriber } from 'rxjs/Subscriber';
-import * as firebase from 'firebase/app';
+import { DocumentChangeType, DocumentChange, CollectionReference, Query } from '@firebase/firestore-types';
 
 export interface DocumentChangeAction {
-  type: firebase.firestore.DocumentChangeType;
-  payload: firebase.firestore.DocumentChange;
+  type: DocumentChangeType;
+  payload: DocumentChange;
 }
 
 export interface Action<T> {
@@ -17,24 +17,24 @@ export interface Reference<T> {
 
 // A convience type for making a query.
 // Example: const query = (ref) => ref.where('name', == 'david');
-export type QueryFn = (ref: firebase.firestore.CollectionReference) => firebase.firestore.Query;
+export type QueryFn = (ref: CollectionReference) => Query;
 
 /**
  * A structure that provides an association between a reference
  * and a query on that reference. Note: Performing operations
  * on the reference can lead to confusing results with complicated
  * queries.
- * 
- * Example: 
- * 
+ *
+ * Example:
+ *
  * const query = ref.where('type', '==', 'Book').
  *                  .where('price', '>' 18.00)
  *                  .where('price', '<' 100.00)
  *                  .where('category', '==', 'Fiction')
  *                  .where('publisher', '==', 'BigPublisher')
- * 
+ *
  * // This addition would not be a result of the query above
- * ref.add({ 
+ * ref.add({
  *  type: 'Magazine',
  *  price: 4.99,
  *  category: 'Sports',
@@ -42,6 +42,6 @@ export type QueryFn = (ref: firebase.firestore.CollectionReference) => firebase.
  * });
  */
 export interface AssociatedReference {
-  ref: firebase.firestore.CollectionReference;
-  query: firebase.firestore.Query;
+  ref: CollectionReference;
+  query: Query;
 }

--- a/src/firestore/observable/fromRef.ts
+++ b/src/firestore/observable/fromRef.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { DocumentReference, Query, QuerySnapshot, DocumentSnapshot } from '@firebase/firestore-types';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { Subscription } from 'rxjs/Subscription';
@@ -17,15 +17,15 @@ function _fromRef<T, R>(ref: Reference<T>): Observable<R> {
   return observeOn.call(ref$, new ZoneScheduler(Zone.current));
 }
 
-export function fromRef<R>(ref: firebase.firestore.DocumentReference | firebase.firestore.Query) {
+export function fromRef<R>(ref: DocumentReference | Query) {
   return _fromRef<typeof ref, R>(ref).share();
 }
 
-export function fromDocRef(ref: firebase.firestore.DocumentReference): Observable<Action<firebase.firestore.DocumentSnapshot>>{
-  return fromRef<firebase.firestore.DocumentSnapshot>(ref)
+export function fromDocRef(ref: DocumentReference): Observable<Action<DocumentSnapshot>>{
+  return fromRef<DocumentSnapshot>(ref)
     .map(payload => ({ payload, type: 'value' }));
 }
 
-export function fromCollectionRef(ref: firebase.firestore.Query): Observable<Action<firebase.firestore.QuerySnapshot>> {
-  return fromRef<firebase.firestore.QuerySnapshot>(ref).map(payload => ({ payload, type: 'query' }))
+export function fromCollectionRef(ref: Query): Observable<Action<QuerySnapshot>> {
+  return fromRef<QuerySnapshot>(ref).map(payload => ({ payload, type: 'query' }))
 }

--- a/src/firestore/utils.spec.ts
+++ b/src/firestore/utils.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { FirebaseFirestore, CollectionReference } from '@firebase/firestore-types';
 import { AngularFirestoreCollection } from './collection/collection';
 
 export interface Stock {
@@ -10,7 +10,7 @@ export const FAKE_STOCK_DATA = { name: 'FAKE', price: 1 };
 
 export const randomName = (firestore): string => firestore.collection('a').doc().id;
 
-export const createRandomStocks = async (firestore: firebase.firestore.Firestore, collectionRef: firebase.firestore.CollectionReference, numberOfItems) => {
+export const createRandomStocks = async (firestore: FirebaseFirestore, collectionRef: CollectionReference, numberOfItems) => {
   // Create a batch to update everything at once
   const batch = firestore.batch();
   // Store the random names to delete them later
@@ -48,4 +48,4 @@ export function delayDelete<T>(collection: AngularFirestoreCollection<T>, path, 
   setTimeout(() => {
     collection.doc(path).delete();
   }, delay);
-}  
+}

--- a/src/storage/observable/fromTask.ts
+++ b/src/storage/observable/fromTask.ts
@@ -1,9 +1,9 @@
-import { storage } from 'firebase/app';
+import { UploadTask, UploadTaskSnapshot } from '@firebase/storage-types';
 import { Observable } from 'rxjs/Observable';
 
-export function fromTask(task: storage.UploadTask) {
-  return new Observable<storage.UploadTaskSnapshot | undefined>(subscriber => {
-    const progress = (snap: storage.UploadTaskSnapshot) => subscriber.next(snap);
+export function fromTask(task: UploadTask) {
+  return new Observable<UploadTaskSnapshot | undefined>(subscriber => {
+    const progress = (snap: UploadTaskSnapshot) => subscriber.next(snap);
     const error = e => subscriber.error(e);
     const complete = () => subscriber.complete();
     task.on('state_changed', progress, error, complete);

--- a/src/storage/ref.ts
+++ b/src/storage/ref.ts
@@ -1,4 +1,4 @@
-import { storage } from 'firebase/app';
+import { SettableMetadata, UploadMetadata, Reference, StringFormat } from '@firebase/storage-types';
 import { createUploadTask, AngularFireUploadTask } from './task';
 import { Observable } from 'rxjs/Observable';
 import { from } from 'rxjs/observable/from';
@@ -8,30 +8,30 @@ export interface AngularFireStorageReference {
   getMetadata(): Observable<any>;
   delete(): Observable<any>;
   child(path: string): any;
-  updateMetatdata(meta: storage.SettableMetadata): Observable<any>;
-  put(data: any, metadata?: storage.UploadMetadata | undefined): AngularFireUploadTask;
-  putString(data: string, format?: string | undefined, metadata?: storage.UploadMetadata | undefined): AngularFireUploadTask;
+  updateMetatdata(meta: SettableMetadata): Observable<any>;
+  put(data: any, metadata?: UploadMetadata | undefined): AngularFireUploadTask;
+  putString(data: string, format?: string | undefined, metadata?: UploadMetadata | undefined): AngularFireUploadTask;
 }
 
 /**
  * Create an AngularFire wrapped Storage Reference. This object
  * creates observable methods from promise based methods.
- * @param ref 
+ * @param ref
  */
-export function createStorageRef(ref: storage.Reference): AngularFireStorageReference {
+export function createStorageRef(ref: Reference): AngularFireStorageReference {
   return {
     getDownloadURL() { return from(ref.getDownloadURL()); },
     getMetadata() { return from(ref.getMetadata()) },
     delete() { return from(ref.delete()); },
     child(path: string) { return createStorageRef(ref.child(path)); },
-    updateMetatdata(meta: storage.SettableMetadata) { 
-      return from(ref.updateMetadata(meta)); 
+    updateMetatdata(meta: SettableMetadata) {
+      return from(ref.updateMetadata(meta));
     },
-    put(data: any, metadata?: storage.UploadMetadata) {
+    put(data: any, metadata?: UploadMetadata) {
       const task = ref.put(data, metadata);
       return createUploadTask(task);
     },
-    putString(data: string, format?: storage.StringFormat, metadata?: storage.UploadMetadata) {
+    putString(data: string, format?: StringFormat, metadata?: UploadMetadata) {
       const task = ref.putString(data, format, metadata);
       return createUploadTask(task);
     }

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -1,6 +1,4 @@
 import { NgModule } from '@angular/core';
-import * as firebase from 'firebase/app';
-import 'firebase/storage';
 import { AngularFireModule, FirebaseApp } from 'angularfire2';
 import { AngularFireStorage } from './storage';
 

--- a/src/storage/storage.spec.ts
+++ b/src/storage/storage.spec.ts
@@ -1,4 +1,4 @@
-import * as firebase from 'firebase/app';
+import { FirebaseApp as FBApp } from '@firebase/app-types';
 import { Observable } from 'rxjs/Observable'
 import { forkJoin } from 'rxjs/observable/forkJoin';
 import { TestBed, inject } from '@angular/core/testing';
@@ -7,7 +7,7 @@ import { AngularFireStorageModule, AngularFireStorage } from 'angularfire2/stora
 import { COMMON_CONFIG } from './test-config';
 
 describe('AngularFireStorage', () => {
-  let app: firebase.app.App;
+  let app: FBApp;
   let afStorage: AngularFireStorage;
 
   beforeEach(() => {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { storage } from 'firebase/app';
+import { FirebaseStorage, UploadMetadata } from '@firebase/storage-types';
 import { FirebaseApp } from 'angularfire2';
 import { createStorageRef, AngularFireStorageReference } from './ref';
 import { createUploadTask, AngularFireUploadTask } from './task';
@@ -7,16 +7,16 @@ import { Observable } from 'rxjs/Observable';
 
 /**
  * AngularFireStorage Service
- * 
+ *
  * This service is the main entry point for this feature module. It provides
  * an API for uploading and downloading binary files from Cloud Storage for
  * Firebase.
- * 
+ *
  */
 @Injectable()
 export class AngularFireStorage {
-  storage: storage.Storage;
-  
+  storage: FirebaseStorage;
+
     constructor(public app: FirebaseApp) {
       this.storage = app.storage();
     }
@@ -25,7 +25,7 @@ export class AngularFireStorage {
       return createStorageRef(this.storage.ref(path));
     }
 
-    upload(path: string, data: any, metadata?: storage.UploadMetadata) {
+    upload(path: string, data: any, metadata?: UploadMetadata) {
       const storageRef = this.storage.ref(path);
       const ref = createStorageRef(storageRef);
       return ref.put(data, metadata);

--- a/src/storage/task.ts
+++ b/src/storage/task.ts
@@ -1,10 +1,10 @@
-import { storage } from 'firebase/app';
+import { UploadTaskSnapshot, UploadTask } from '@firebase/storage-types';
 import { fromTask } from './observable/fromTask';
 import { Observable } from 'rxjs/Observable';
 import { map, filter } from 'rxjs/operators';
 
 export interface AngularFireUploadTask {
-  snapshotChanges(): Observable<storage.UploadTaskSnapshot | undefined>;
+  snapshotChanges(): Observable<UploadTaskSnapshot | undefined>;
   percentageChanges(): Observable<number | undefined>;
   downloadURL(): Observable<string | null>;
   pause(): boolean;
@@ -14,18 +14,18 @@ export interface AngularFireUploadTask {
   catch(onRejected: (a: Error) => any): Promise<any>;
 }
 
-export function createUploadTask(task: storage.UploadTask): AngularFireUploadTask {
+export function createUploadTask(task: UploadTask): AngularFireUploadTask {
   const inner$ = fromTask(task);
-  return { 
-    pause() { return task.pause(); },    
-    cancel() { return task.cancel(); },    
-    resume() { return task.resume(); },    
-    then() { return task.then(); },    
-    catch(onRejected: (a: Error) => any) { 
+  return {
+    pause() { return task.pause(); },
+    cancel() { return task.cancel(); },
+    resume() { return task.resume(); },
+    then() { return task.then(); },
+    catch(onRejected: (a: Error) => any) {
       return task.catch(onRejected);
     },
-    snapshotChanges() { return inner$; },   
-    percentageChanges() { 
+    snapshotChanges() { return inner$; },
+    percentageChanges() {
       return inner$.pipe(
         filter(s => s !== undefined),
         map(s => s!.bytesTransferred / s!.totalBytes * 100)

--- a/tools/build.js
+++ b/tools/build.js
@@ -54,11 +54,11 @@ const GLOBALS = {
   '@angular/core': 'ng.core',
   '@angular/compiler': 'ng.compiler',
   '@angular/platform-browser': 'ng.platformBrowser',
-  'firebase/auth': 'firebase',
-  'firebase/app': 'firebase',
-  'firebase/database': 'firebase',
-  'firebase/firestore': 'firebase',
-  'firebase/storage': 'firebase',
+  '@firebase/auth': 'firebase',
+  '@firebase/app': 'firebase',
+  '@firebase/database': 'firebase',
+  '@firebase/firestore': 'firebase',
+  '@firebase/storage': 'firebase',
   'rxjs/scheduler/queue': 'Rx.Scheduler',
   '@angular/core/testing': 'ng.core.testing',
   'angularfire2': 'angularfire2',
@@ -123,8 +123,8 @@ const TSC_TEST_ARGS = [`-p`, `${process.cwd()}/src/tsconfig-test.json`];
 
 /**
  * Create an Observable of a spawned child process.
- * @param {string} command 
- * @param {string[]} args 
+ * @param {string} command
+ * @param {string[]} args
  */
 function spawnObservable(command, args) {
   return Observable.create(observer => {
@@ -151,8 +151,8 @@ function generateBundle(entry, { dest, globals, moduleName }) {
 
 /**
  * Create a UMD bundle given a module name.
- * @param {string} name 
- * @param {Object} globals 
+ * @param {string} name
+ * @param {Object} globals
  */
 function createUmd(name, globals) {
   // core module is angularfire2 the rest are angularfire2.feature
@@ -177,7 +177,7 @@ function createTestUmd(globals) {
 
 /**
  * Get the file path of the src package.json for a module
- * @param {string} moduleName 
+ * @param {string} moduleName
  */
 function getSrcPackageFile(moduleName) {
   return SRC_PKG_PATHS[moduleName];
@@ -185,7 +185,7 @@ function getSrcPackageFile(moduleName) {
 
 /**
  * Get the file path of the dist package.json for a module
- * @param {string} moduleName 
+ * @param {string} moduleName
  */
 function getDestPackageFile(moduleName) {
   return DEST_PKG_PATHS[moduleName];
@@ -194,8 +194,8 @@ function getDestPackageFile(moduleName) {
 /**
  * Create an observable of package.json dependency version replacements.
  * This keeps the dependency versions across each package in sync.
- * @param {string} name 
- * @param {Object} versions 
+ * @param {string} name
+ * @param {Object} versions
  */
 function replaceVersionsObservable(name, versions) {
   return Observable.create((observer) => {
@@ -287,7 +287,7 @@ function buildModule(name, globals) {
 
 /**
  * Create an observable of module build status. This method builds
- * @param {Object} globals 
+ * @param {Object} globals
  */
 function buildModules(globals) {
   const core$ = buildModule('core', globals);


### PR DESCRIPTION

### Checklist

   - Issue number for this PR: #1385, [#334](https://github.com/firebase/firebase-js-sdk/pull/334)
   - Docs included?: no, I was not sure if there was a document that needed to be updated for this.
   - Test units included?: yes, all tests upgraded
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

With [#334](https://github.com/firebase/firebase-js-sdk/pull/334) from firebase-js-sdk being released in 4.8.1, this breaks the imports for angularfire2. This commit resolves that by updating to the new typings that were released in 4.8.1. I did not bump the package version for firebase to above 4.8.1 but since this is not a backwards compatible change that might be important to do. There was also a name collision with FirebaseApp so I choose to cast the upstream to FBApp until the proper solution can be determined. Let me know if there are any issues with the solution and I will address them! Thanks for your consideration.
