### PR TITLE
fix(afs): fix di warning

### DIFF
--- a/src/firestore/enable-persistance-token.ts
+++ b/src/firestore/enable-persistance-token.ts
@@ -1,0 +1,6 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * The value of this token determines whether or not the firestore will have persistance enabled
+ */
+export const EnablePersistenceToken = new InjectionToken<boolean>('EnablePersistenceToken');

--- a/src/firestore/firestore.module.ts
+++ b/src/firestore/firestore.module.ts
@@ -1,36 +1,25 @@
-import { NgModule, InjectionToken } from '@angular/core';
+import { InjectionToken, ModuleWithProviders, NgModule } from '@angular/core';
 import { FirebaseApp, AngularFireModule } from 'angularfire2';
 import { AngularFirestore } from './firestore';
 import { from } from 'rxjs/observable/from';
 
-export const EnablePersistenceToken = new InjectionToken<boolean>('EnablePersistenceToken');
-
-export function _getAngularFirestore(app: FirebaseApp, enablePersistence: boolean) {
-  return new AngularFirestore(app, enablePersistence);
-}
-
-export const AngularFirestoreProvider = {
-  provide: AngularFirestore,
-  useFactory: _getAngularFirestore,
-  deps: [ FirebaseApp, EnablePersistenceToken ]
-};
-
-export const FIRESTORE_PROVIDERS = [
-  AngularFirestoreProvider,
-  { provide: EnablePersistenceToken, useValue: false },
-];
+import { EnablePersistenceToken } from './enable-persistance-token';
 
 @NgModule({
   imports: [ AngularFireModule ],
-  providers: [ FIRESTORE_PROVIDERS ]
+  providers: [
+    AngularFirestore,
+  ]
 })
 export class AngularFirestoreModule {
-  static enablePersistence() {
+  /**
+   * Attempt to enable persistent storage, if possible
+   */
+  static enablePersistence(): ModuleWithProviders {
     return {
-      ngModule: AngularFireModule,
+      ngModule: AngularFirestoreModule,
       providers: [
         { provide: EnablePersistenceToken, useValue: true },
-        AngularFirestoreProvider
       ]
     }
   }

--- a/src/firestore/firestore.spec.ts
+++ b/src/firestore/firestore.spec.ts
@@ -79,3 +79,29 @@ describe('AngularFirestore', () => {
   });
 
 });
+
+describe('AngularFirestore without persistance', () => {
+  let app: FBApp;
+  let afs: AngularFirestore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        AngularFireModule.initializeApp(COMMON_CONFIG),
+        AngularFirestoreModule
+      ]
+    });
+    inject([FirebaseApp, AngularFirestore], (_app: FBApp, _afs: AngularFirestore) => {
+      app = _app;
+      afs = _afs;
+    })();
+  });
+
+  it('should not enable persistence', (done) => {
+    afs.persistenceEnabled$.subscribe(isEnabled => {
+      expect(isEnabled).toBe(false);
+      done();
+    });
+  });
+
+});

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -4,12 +4,13 @@ import { Subscriber } from 'rxjs/Subscriber';
 import { from } from 'rxjs/observable/from';
 import 'rxjs/add/operator/map';
 
-import { Injectable } from '@angular/core';
+import { Injectable, Inject, Optional } from '@angular/core';
 import { FirebaseApp } from 'angularfire2';
 
 import { QueryFn, AssociatedReference } from './interfaces';
 import { AngularFirestoreDocument } from './document/document';
 import { AngularFirestoreCollection } from './collection/collection';
+import { EnablePersistenceToken } from './enable-persistance-token';
 
 
 /**
@@ -96,7 +97,7 @@ export class AngularFirestore {
    * apps and use multiple apps.
    * @param app
    */
-  constructor(public app: FirebaseApp, shouldEnablePersistence) {
+  constructor(public app: FirebaseApp, @Optional() @Inject(EnablePersistenceToken) shouldEnablePersistence: boolean) {
     this.firestore = app.firestore();
 
     this.persistenceEnabled$ = shouldEnablePersistence ?


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #1206  (required)
   - Docs included?: yes 
   - Test units included?: yes
   - In a clean directory, `npm install`, `npm run build`, and `npm test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Fixing Error with Dependency Injection not being able to resolve all parameters in an Injectable class.

AngularFirestore is an Injectable class meaning its parameters must be resolvable via Dependency Injection.

Its current inability to do this, results in the warning:

```sh
Warning: Can't resolve all parameters for AngularFirestore in /XXXProjectPathXXX/node_modules/angularfire2/firestore/index.d.ts: ([object Object], ?). This will become an error in Angular v6.x
```

Using the injected Token allows the shouldEnablePersistence parameter to be resolvable via DI thus fixing the above warning!

Implementation Caveat:

* EnablePersistenceToken had to be moved to its own file in order to prevent circular module dependencies. A possible alternative would be to export this token from firestore.ts

Bonus:

* Slightly refactored the definition of FirestoreModule to only provide AngularFirestore as a provider
  * The EnablePersistenceToken only gets injected if it the enablePersistence function is called

### Code sample

No API Changes

