### PR TITLE
Update rtdb object docs to reflect version 5.0.0. Change from FirebaseObservable to Observable

### DIFF
--- a/docs/rtdb/objects.md
+++ b/docs/rtdb/objects.md
@@ -58,7 +58,7 @@ import { Observable } from 'rxjs/Observable';
   `,
 })
 export class AppComponent {
-  item: FirebaseObjectObservable<any>;
+  item: Observable<any>;
   constructor(db: AngularFireDatabase) {
     this.item = db.object('item').valueChanges();
   }


### PR DESCRIPTION
### Description

Small change to Real Time Database Docs. Still referencing FirebaseObservable on Object referencing. Should be Observable<any> not FirebaseObservable<any>.

### Doc Change
From -> item: FirebaseObservable<any>;

To ->   item: Observable<any>;




