### PR TITLE
feat(firestore): allow collection and doc from ref

### DIFF
--- a/src/firestore/firestore.spec.ts
+++ b/src/firestore/firestore.spec.ts
@@ -47,13 +47,25 @@ describe('AngularFirestore', () => {
     expect(afs.app).toBeDefined();
   });
 
-  it('should create an AngularFirestoreDocument', () => {
+  it('should create an AngularFirestoreDocument from a string path', () => {
     const doc = afs.doc('a/doc');
     expect(doc instanceof AngularFirestoreDocument).toBe(true);
   });
 
-  it('should create an AngularFirestoreCollection', () => {
+  it('should create an AngularFirestoreDocument from a string path', () => {
+    const ref = afs.doc('a/doc').ref;
+    const doc = afs.doc(ref);
+    expect(doc instanceof AngularFirestoreDocument).toBe(true);
+  });
+
+  it('should create an AngularFirestoreCollection from a string path', () => {
     const collection = afs.collection('stuffs');
+    expect(collection instanceof AngularFirestoreCollection).toBe(true);
+  });
+
+  it('should create an AngularFirestoreCollection from a reference', () => {
+    const ref = afs.collection('stuffs').ref;
+    const collection = afs.collection(ref);
     expect(collection instanceof AngularFirestoreCollection).toBe(true);
   });
 

--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -1,4 +1,4 @@
-import { FirebaseFirestore, CollectionReference } from '@firebase/firestore-types';
+import { FirebaseFirestore, CollectionReference, DocumentReference } from '@firebase/firestore-types';
 import { Observable } from 'rxjs/Observable';
 import { Subscriber } from 'rxjs/Subscriber';
 import { from } from 'rxjs/observable/from';
@@ -106,25 +106,41 @@ export class AngularFirestore {
   }
 
   /**
-   * Create a reference to a Firestore Collection based on a path and an optional
-   * query function to narrow the result set.
-   * @param path
+   * Create a reference to a Firestore Collection based on a path or
+   * CollectionReference and an optional query function to narrow the result
+   * set.
+   * @param pathOrRef
    * @param queryFn
    */
-  collection<T>(path: string, queryFn?: QueryFn): AngularFirestoreCollection<T> {
-    const collectionRef = this.firestore.collection(path);
+  collection<T>(path: string, queryFn?: QueryFn): AngularFirestoreCollection<T>
+  collection<T>(ref: CollectionReference, queryFn?: QueryFn): AngularFirestoreCollection<T>
+  collection<T>(pathOrRef: string | CollectionReference, queryFn?: QueryFn): AngularFirestoreCollection<T> {
+    let collectionRef: CollectionReference;
+    if (typeof pathOrRef === 'string') {
+      collectionRef = this.firestore.collection(pathOrRef);
+    } else {
+      collectionRef = pathOrRef;
+    }
     const { ref, query } = associateQuery(collectionRef, queryFn);
     return new AngularFirestoreCollection<T>(ref, query);
   }
 
   /**
-   * Create a reference to a Firestore Document based on a path. Note that documents
-   * are not queryable because they are simply objects. However, documents have
-   * sub-collections that return a Collection reference and can be queried.
-   * @param path
+   * Create a reference to a Firestore Document based on a path or
+   * DocumentReference. Note that documents are not queryable because they are
+   * simply objects. However, documents have sub-collections that return a
+   * Collection reference and can be queried.
+   * @param pathOrRef
    */
-  doc<T>(path: string): AngularFirestoreDocument<T> {
-    const ref = this.firestore.doc(path);
+  doc<T>(path: string): AngularFirestoreDocument<T>
+  doc<T>(ref: DocumentReference): AngularFirestoreDocument<T>
+  doc<T>(pathOrRef: string | DocumentReference): AngularFirestoreDocument<T> {
+    let ref: DocumentReference;
+    if (typeof pathOrRef === 'string') {
+      ref = this.firestore.doc(pathOrRef);
+    } else {
+      ref = pathOrRef;
+    }
     return new AngularFirestoreDocument<T>(ref);
   }
 


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #1337 (required)
   - Docs included?: no
   - Test units included?: yes)
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes


### Description
Allows firestore collection and doc to be constructed from both references and string paths.

Do I need to add better tests? I was not sure how to get a reference easily, so I just took one from `afs`, which seems a bit backwards in a way.

Also not sure if there are any required documentation changes. Let me know in that case!
### Code sample

Changes the interfaces to: 
```typescript
collection<T>(pathOrRef: string | CollectionReference, queryFn?: QueryFn): AngularFirestoreCollection<T>
doc<T>(pathOrRef: string | DocumentReference): AngularFirestoreDocument<T>
```
