### PR TITLE
Fixed typo in storage.md - (on change) should be (change)

### DIFF
--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -60,7 +60,7 @@ import { AngularFireStorage } from 'angularfire2/storage';
 @Component({
   selector: 'app-root',
   template: `
-  <input type="file" (onchange)="uploadFile($event)">
+  <input type="file" (change)="uploadFile($event)">
   `
 })
 export class AppComponent {


### PR DESCRIPTION
Tiny typo in documentation

### Checklist

   - Issue number for this PR: #1504
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully?: yes

### Description

Just solved a tiny event binding typo in the storage.md file (topic: **AngularFireStorage**). 

