### PR TITLE
Adding a test matrix and using the lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
     if $CANARY; then
       yarn upgrade && yarn install firebase@canary
     else
-      if $TRAVIS_PULL_REQUEST="false"; then
+      if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
         yarn upgrade
       else
         yarn install --frozen-lockfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,25 @@ cache:
     - "$HOME/.npm"
     - "$HOME/.cache"
 
+# Just use yarn commands for now, as this gets more complex lets break out
+# into a shell script
+env:
+  - YARN_COMMAND="install --frozen-lockfile"
+  - YARN_COMMAND="upgrade"
+  - YARN_COMMAND="upgrade && yarn add firebase@canary"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: YARN_COMMAND="upgrade"
+    - env: YARN_COMMAND="upgrade && yarn add firebase@canary"
+
 branches:
   only:
     - master # otherwise pull requests get built twice
 
 install:
-  - yarn install
+  - yarn `echo $YARN_COMMAND`
 
 script:
   - yarn run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,25 +13,30 @@ cache:
     - "$HOME/.npm"
     - "$HOME/.cache"
 
-# Just use yarn commands for now, as this gets more complex lets break out
-# into a shell script
 env:
-  - YARN_COMMAND="install --frozen-lockfile"
-  - YARN_COMMAND="upgrade"
-  - YARN_COMMAND="upgrade && yarn add firebase@canary"
+  - CANARY=false
+  - CANARY=true
 
 matrix:
   fast_finish: true
   allow_failures:
-    - env: YARN_COMMAND="upgrade"
-    - env: YARN_COMMAND="upgrade && yarn add firebase@canary"
+    - env: CANARY=true
 
 branches:
   only:
     - master # otherwise pull requests get built twice
 
 install:
-  - yarn `echo $YARN_COMMAND`
+  - |
+    if $CANARY; then
+      yarn upgrade && yarn install firebase@canary
+    else
+      if $TRAVIS_PULL_REQUEST="false"; then
+        yarn upgrade
+      else
+        yarn install --frozen-lockfile
+      fi
+    fi
 
 script:
   - yarn run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ branches:
 install:
   - |
     if $CANARY; then
-      yarn upgrade && yarn install firebase@canary
+      yarn upgrade && yarn add firebase@canary
     else
       if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
         yarn upgrade


### PR DESCRIPTION
Tests on PRs are red right now, becuase Firebase JS SDK is breaking. Fix how were testing. 

A) if it's a PR, use the lockfile
B) if it's master, upgrade (this is so we're alerted of failure on Cron every night)
C) add a canary test, which is allowed to fail. I will work with the JS SDK team to make sure they're alerted of these failures

https://github.com/firebase/firebase-js-sdk/issues/605