### PR TITLE
docs(firestore): update documents type information (#1331)

### DIFF
--- a/docs/firestore/documents.md
+++ b/docs/firestore/documents.md
@@ -33,25 +33,17 @@ export class AppComponent {
 }
 ```
 
-### The `DocumentChangeAction` type
+### Document types
 
-With the exception of the `valueChanges()`, each streaming method returns an Observable of `DocumentChangeAction[]`.
+With the exception of the `valueChanges()`, each streaming method returns an Observable of `Action<DocumentSnapshot>`.
 
-A `DocumentChangeAction` gives you the `type` and `payload` properties. The `type` tells when what `DocumentChangeType` operation occured (`added`, `modified`, `removed`). The `payload` property is a `DocumentChange` which provides you important metadata about the change and a `doc` property which is the `DocumentSnapshot`.
+An `Action` gives you the `type` and `payload` properties. The `type` tells what `DocumentChangeType` operation occured (`added`, `modified`, `removed`). The `payload` property is a `DocumentSnapshot` which provides you important metadata about the change.
 
 ```ts
-interface DocumentChangeAction {
-  //'added' | 'modified' | 'removed';
-  type: DocumentChangeType;
-  payload: DocumentChange;
-}
-
-interface DocumentChange {
-  type: DocumentChangeType;
-  doc: DocumentSnapshot;
-  oldIndex: number;
-  newIndex: number;
-}
+interface Action<T> {
+  type: string;
+  payload: T;
+};
 
 interface DocumentSnapshot {
   exists: boolean;
@@ -75,9 +67,9 @@ There are multiple ways of streaming collection data from Firestore.
 **When would you not use it?** - When you need the `id` of the document to use data manipulation methods. This method assumes you either are saving the `id` to the document data or using a "readonly" approach.
 
 ### `snapshotChanges()`
-**What is it?** - Returns an Observable of data as a `DocumentChangeAction`. 
+**What is it?** - Returns an Observable of data as an `Action<DocumentSnapshot>`. 
 
-**Why would you use it?** - When you need the document data but also want to keep around metadata. This metadata provides you the underyling `DocumentReference` and document id. Having the document's id around makes it easier to use data manipulation methods. This method gives you more horsepower with other Angular integrations such as ngrx, forms, and animations due to the `type` property. The `type` property on each `DocumentChangeAction` is useful for ngrx reducers, form states, and animation states.
+**Why would you use it?** - When you need the document data but also want to keep around metadata. This metadata provides you the underyling `DocumentReference` and document id. Having the document's id around makes it easier to use data manipulation methods. This method gives you more horsepower with other Angular integrations such as ngrx, forms, and animations due to the `type` property. The `type` property on each `Action` is useful for ngrx reducers, form states, and animation states.
 
 **When would you not use it?** - When you simply need to render data to a view and don't want to do any extra processing.
 


### PR DESCRIPTION
Issue number for this PR: #1331 

I was going through the docs this evening while learning about angularfire2 for a side project and realized the types outlined in the docs for firestore documents don't match up with what's happening in the code. This is a quick update to the docs. Please advise if this is not the desired approach, just trying to be helpful if I can!