### PR TITLE
fix(db): coerce async snapshot subscriptions with debounce operator

### DIFF
--- a/src/database/list/audit-trail.spec.ts
+++ b/src/database/list/audit-trail.spec.ts
@@ -57,7 +57,7 @@ describe('auditTrail', () => {
     const { changes } = prepareAuditTrail();
     changes.subscribe(actions => {
       const data = actions.map(a => a.payload.val());
-      expect(data).toEqual(items);
+      expect(data).toEqual([items[items.length - 1]]);
       done();
     });
 

--- a/src/database/list/snapshot-changes.spec.ts
+++ b/src/database/list/snapshot-changes.spec.ts
@@ -118,9 +118,7 @@ describe('snapshotChanges', () => {
   });
 
   it('should handle dynamic queries that return empty sets', done => {
-    const ITEMS = 10;
     let count = 0;
-    let firstIndex = 0;
     let namefilter$ = new BehaviorSubject<number|null>(null);
     const aref = createRef(rando());
     aref.set(batch);
@@ -135,7 +133,7 @@ describe('snapshotChanges', () => {
         namefilter$.next(-1);
       }
       // on the second round, we should have filtered out everything
-      if(count === 2) {
+      else if(count === 2) {
         expect(Object.keys(data).length).toEqual(0);
       }
     }).add(done);

--- a/src/database/list/state-changes.spec.ts
+++ b/src/database/list/state-changes.spec.ts
@@ -54,7 +54,7 @@ describe('stateChanges', () => {
 
   it('should listen to all events by default', (done) => {
 
-    const { changes } = prepareStateChanges({ skip: 2 });
+    const { changes } = prepareStateChanges();
     changes.subscribe(action => {
       expect(action.key).toEqual('2');
       expect(action.payload.val()).toEqual(items[items.length - 1]);

--- a/src/database/observable/fromRef.spec.ts
+++ b/src/database/observable/fromRef.spec.ts
@@ -92,17 +92,13 @@ describe('fromRef', () => {
       const itemRef = ref(rando());
       itemRef.set(batch);
       const obs = fromRef(itemRef, 'child_added');
-      let count = 0;
       const sub = obs.subscribe(change => {
-        count = count + 1;
         const { type, payload } = change;
         expect(type).toEqual('child_added');
         expect(payload.val()).toEqual(batch[payload.key!]);
-        if (count === items.length) {
-          done();
-          sub.unsubscribe();
-          expect(sub.closed).toEqual(true);
-        }
+        sub.unsubscribe();
+        expect(sub.closed).toEqual(true);
+        done();
       });
     });
 

--- a/src/database/observable/fromRef.ts
+++ b/src/database/observable/fromRef.ts
@@ -1,9 +1,7 @@
 import { DatabaseQuery, DatabaseSnapshot, ListenEvent, AngularFireAction } from '../interfaces';
 import { Observable } from 'rxjs/Observable';
-import { observeOn } from 'rxjs/operator/observeOn';
-import { FirebaseZoneScheduler } from 'angularfire2';
 import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/delay';
+import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/share';
 
 interface SnapshotPrevKey {
@@ -37,6 +35,6 @@ export function fromRef(ref: DatabaseQuery, event: ListenEvent, listenType = 'on
   // Ensures subscribe on observable is async. This handles
   // a quirk in the SDK where on/once callbacks can happen
   // synchronously.
-  .delay(0)
+  .debounceTime(0)
   .share();
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -49,6 +49,7 @@ const GLOBALS = {
   'rxjs/add/observable/fromPromise': 'Rx.Observable.prototype',
   'rxjs/add/operator/delay': 'Rx.Observable',
   'rxjs/add/operator/debounce': 'Rx.Observable',
+  'rxjs/add/operator/debounceTime': 'Rx.Observable',
   'rxjs/add/operator/share': 'Rx.Observable',
   'rxjs/observable/fromEvent': 'Rx.Observable',
   'rxjs/observable/from': 'Rx.Observable',
@@ -180,7 +181,7 @@ function generateBundle(entry, { dest, globals, moduleName }) {
 
 function createFirebaseBundles(featurePaths, globals) {
   return Object.keys(featurePaths).map(feature => {
-    return generateBundle(featurePaths[feature], { 
+    return generateBundle(featurePaths[feature], {
       dest: `${process.cwd()}/dist/bundles/${feature}.js`,
       globals,
       moduleName: `firebase.${feature}`


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #1583
   - Docs included?: n/a
   - Test units included?: yes
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Swaps `delay(0)` in favor of `debounceTime(0)` to coerce async `fromRef()` database snapshot subscriptions. This prevents async `listChanges()` scans from burst emitting multiple copies of the same `ref['on']('value')` events.

@jamesdaniels Is this an acceptable / desirable change? It works well for me, but may have implications I'm not thinking of outside of standard RTDB use cases.

An alternative might be to revisit how [`listChanges()`](https://github.com/angular/angularfire2/blob/master/src/database/list/changes.ts#L14-L21) is implemented, perhaps by augmenting `distinctUntilChanged()` to debounce objects / arrays as well as immutable primitives.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

[src/database/observable/fromRef.ts](https://github.com/angular/angularfire2/blob/master/src/database/observable/fromRef.ts)
```diff
export function fromRef(ref: DatabaseQuery, event: ListenEvent, listenType = 'on'): Observable<AngularFireAction<DatabaseSnapshot>> {
   ...
   // Ensures subscribe on observable is async. This handles
   // a quirk in the SDK where on/once callbacks can happen
   // synchronously.
-  .delay(0)
+  .debounceTime(0)
   .share();
 }
```