### PR TITLE
fix(core): only import typing from zone.js

### DIFF
--- a/src/core/angularfire2.ts
+++ b/src/core/angularfire2.ts
@@ -8,7 +8,7 @@ import { observeOn } from 'rxjs/operator/observeOn';
 import firebase from '@firebase/app';
 import { FirebaseApp, FirebaseOptions } from '@firebase/app-types';
 
-import 'zone.js';
+import {} from 'zone.js';
 import 'rxjs/add/operator/first';
 
 export const FirebaseAppName = new InjectionToken<string>('angularfire2.appName');


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #1597  (required)
   - Docs included?: no (yes/no; required for all API/functional changes) 
   - Test units included?: no (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Should only `import {} from 'zone.js'` to import typing, but not import `zone.js` again, otherwise it will report `Zone is already loaded` error.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

@jamesdaniels , please review, thank you.