### PR TITLE
fix(firestore): default sub-collections to DocumentData

### DIFF
--- a/src/firestore/document/document.ts
+++ b/src/firestore/document/document.ts
@@ -70,7 +70,7 @@ export class AngularFirestoreDocument<T=DocumentData> {
    * @param path
    * @param queryFn
    */
-  collection<R>(path: string, queryFn?: QueryFn): AngularFirestoreCollection<R> {
+  collection<R=DocumentData>(path: string, queryFn?: QueryFn): AngularFirestoreCollection<R> {
     const collectionRef = this.ref.collection(path);
     const { ref, query } = associateQuery(collectionRef, queryFn);
     return new AngularFirestoreCollection<R>(ref, query, this.afs);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

Whoops! Thought I got this into RC 9 but I guess not. Sub-collections should default their type to `DocumentData` not `{}`.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

