### PR TITLE
feat(firestore): Add support for SnapshotListenOptions

### DIFF
--- a/src/firestore/collection/changes.ts
+++ b/src/firestore/collection/changes.ts
@@ -1,6 +1,7 @@
 import { fromCollectionRef } from '../observable/fromRef';
 import { Observable } from 'rxjs';
-import { map, filter, scan } from 'rxjs/operators';
+import { map, scan } from 'rxjs/operators';
+import { firestore } from 'firebase';
 
 import { Query, DocumentChangeType, DocumentChange, DocumentChangeAction, Action } from '../interfaces';
 
@@ -9,8 +10,8 @@ import { Query, DocumentChangeType, DocumentChange, DocumentChangeAction, Action
  * order of occurence.
  * @param query
  */
-export function docChanges<T>(query: Query): Observable<DocumentChangeAction<T>[]> {
-  return fromCollectionRef(query)
+export function docChanges<T>(query: Query, options?: firestore.SnapshotListenOptions): Observable<DocumentChangeAction<T>[]> {
+  return fromCollectionRef(query, options)
     .pipe(
       map(action =>
         action.payload.docChanges()
@@ -21,8 +22,8 @@ export function docChanges<T>(query: Query): Observable<DocumentChangeAction<T>[
  * Return a stream of document changes on a query. These results are in sort order.
  * @param query
  */
-export function sortedChanges<T>(query: Query, events: DocumentChangeType[]): Observable<DocumentChangeAction<T>[]> {
-  return fromCollectionRef(query)
+export function sortedChanges<T>(query: Query, events: DocumentChangeType[], options?: firestore.SnapshotListenOptions): Observable<DocumentChangeAction<T>[]> {
+  return fromCollectionRef(query, options)
     .pipe(
       map(changes => changes.payload.docChanges()),
       scan((current, changes) => combineChanges(current, changes, events), []),

--- a/src/firestore/collection/collection.spec.ts
+++ b/src/firestore/collection/collection.spec.ts
@@ -203,6 +203,7 @@ describe('AngularFirestoreCollection', () => {
           deleteThemAll(names, ref).then(done).catch(done.fail);
         }
       });
+
     });
 
     it('should be able to filter snapshotChanges() types - modified', async (done) => {
@@ -284,6 +285,17 @@ describe('AngularFirestoreCollection', () => {
       });
 
       delayDelete(stocks, names[0], 400);
+    });
+
+    it('should work with snapshot listener options', async (done: any) => {
+      const ITEMS = 4;
+      const { randomCollectionName, ref, stocks, names } = await collectionHarness(afs, ITEMS);
+      debugger;
+      const sub = stocks.snapshotChanges({ includeMetadataChanges: true }).subscribe(actions => {
+        sub.unsubscribe();
+        debugger;
+        done();
+      });
     });
 
   });

--- a/src/firestore/collection/collection.spec.ts
+++ b/src/firestore/collection/collection.spec.ts
@@ -275,7 +275,7 @@ describe('AngularFirestoreCollection', () => {
       const ITEMS = 10;
       const { randomCollectionName, ref, stocks, names } = await collectionHarness(afs, ITEMS);
 
-      const sub = stocks.snapshotChanges(['added', 'removed']).pipe(skip(1)).subscribe(data => {
+      const sub = stocks.snapshotChanges(['added', 'removed'], { includeMetadataChanges: true }).pipe(skip(1)).subscribe(data => {
         sub.unsubscribe();
         const change = data.filter(x => x.payload.doc.id === names[0]);
         expect(data.length).toEqual(ITEMS - 1);
@@ -287,14 +287,27 @@ describe('AngularFirestoreCollection', () => {
       delayDelete(stocks, names[0], 400);
     });
 
-    it('should work with snapshot listener options', async (done: any) => {
-      const ITEMS = 4;
+    it('should listen to all snapshotChanges() by default with listener options', async (done) => {
+      const ITEMS = 10;
+      let count = 0;
       const { randomCollectionName, ref, stocks, names } = await collectionHarness(afs, ITEMS);
-      debugger;
-      const sub = stocks.snapshotChanges({ includeMetadataChanges: true }).subscribe(actions => {
-        sub.unsubscribe();
-        debugger;
-        done();
+      const sub = stocks.snapshotChanges({ includeMetadataChanges: true }).subscribe(data => {
+        const ids = data.map(d => d.payload.doc.id);
+        count = count + 1;
+        // the first time should all be 'added'
+        if(count === 1) {
+          // make an update
+          stocks.doc(names[0]).update({ price: 2});
+        }
+        // on the second round, make sure the array is still the same
+        // length but the updated item is now modified
+        if(count === 2) {
+          expect(data.length).toEqual(ITEMS);
+          const change = data.filter(x => x.payload.doc.id === names[0])[0];
+          expect(change.type).toEqual('modified');
+          sub.unsubscribe();
+          deleteThemAll(names, ref).then(done).catch(done.fail);
+        }
       });
     });
 
@@ -358,7 +371,7 @@ describe('AngularFirestoreCollection', () => {
     it('should handle multiple subscriptions (warm)', async (done: any) => {
       const ITEMS = 4;
       const { randomCollectionName, ref, stocks, names } = await collectionHarness(afs, ITEMS);
-      const changes = stocks.stateChanges();
+      const changes = stocks.stateChanges({ includeMetadataChanges: true });
       changes.pipe(take(1)).subscribe(() => {}).add(() => {
         const sub = changes.pipe(take(1)).subscribe(data => {
           expect(data.length).toEqual(ITEMS);
@@ -373,7 +386,7 @@ describe('AngularFirestoreCollection', () => {
       let count = 0;
       const { randomCollectionName, ref, stocks, names } = await collectionHarness(afs, ITEMS);
 
-      const sub = stocks.stateChanges(['modified']).subscribe(data => {
+      const sub = stocks.stateChanges(['modified'], { includeMetadataChanges: true }).subscribe(data => {
         sub.unsubscribe();
         expect(data.length).toEqual(1);
         expect(data[0].payload.doc.data().price).toEqual(2);
@@ -443,7 +456,7 @@ describe('AngularFirestoreCollection', () => {
       const ITEMS = 10;
       const { randomCollectionName, ref, stocks, names } = await collectionHarness(afs, ITEMS);
 
-      const sub = stocks.auditTrail(['removed']).subscribe(data => {
+      const sub = stocks.auditTrail(['removed'], { includeMetadataChanges: true }).subscribe(data => {
         sub.unsubscribe();
         expect(data.length).toEqual(1);
         expect(data[0].type).toEqual('removed');

--- a/src/firestore/document/document.spec.ts
+++ b/src/firestore/document/document.spec.ts
@@ -2,7 +2,7 @@ import { FirebaseApp, AngularFireModule } from 'angularfire2';
 import { AngularFirestore } from '../firestore';
 import { AngularFirestoreModule } from '../firestore.module';
 import { AngularFirestoreDocument } from '../document/document';
-import { Observable, Subscription } from 'rxjs';
+import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 import { TestBed, inject } from '@angular/core/testing';
@@ -40,10 +40,10 @@ describe('AngularFirestoreDocument', () => {
     await stock.set(FAKE_STOCK_DATA);
     const sub = stock
       .snapshotChanges()
-      .subscribe(async a => {
+      .subscribe(a => {
         sub.unsubscribe();
-        if (a.payload.exists) {
-          expect(a.payload.data()).toEqual(FAKE_STOCK_DATA);
+        if (a.exists) {
+          expect(a.data()).toEqual(FAKE_STOCK_DATA);
           stock.delete().then(done).catch(done.fail);
         }
       });

--- a/src/firestore/document/document.ts
+++ b/src/firestore/document/document.ts
@@ -3,8 +3,6 @@ import { DocumentReference, SetOptions, DocumentData, QueryFn, AssociatedReferen
 import { fromDocRef } from '../observable/fromRef';
 import { map } from 'rxjs/operators';
 
-import { Injectable } from '@angular/core';
-
 import { AngularFirestore, associateQuery } from '../firestore';
 import { AngularFirestoreCollection } from '../collection/collection';
 
@@ -78,7 +76,7 @@ export class AngularFirestoreDocument<T=DocumentData> {
   /**
    * Listen to snapshot updates from the document.
    */
-  snapshotChanges(): Observable<Action<DocumentSnapshot<T>>> {
+  snapshotChanges(): Observable<DocumentSnapshot<T>> {
     const fromDocRef$ = fromDocRef<T>(this.ref);
     const scheduledFromDocRef$ = this.afs.scheduler.runOutsideAngular(fromDocRef$);
     return this.afs.scheduler.keepUnstableUntilFirst(scheduledFromDocRef$);
@@ -89,9 +87,7 @@ export class AngularFirestoreDocument<T=DocumentData> {
    */
   valueChanges(): Observable<T|undefined> {
     return this.snapshotChanges().pipe(
-      map(action => {
-        return action.payload.data();
-      })
+      map(snap => snap.data())
     );
   }
 }

--- a/src/firestore/interfaces.ts
+++ b/src/firestore/interfaces.ts
@@ -48,9 +48,7 @@ export interface Action<T> {
   payload: T;
 };
 
-export interface Reference<T> {
-  onSnapshot: (sub: Subscriber<any>) => any;
-}
+export interface Reference<T> extends Query { }
 
 // A convience type for making a query.
 // Example: const query = (ref) => ref.where('name', == 'david');

--- a/src/firestore/observable/fromRef.ts
+++ b/src/firestore/observable/fromRef.ts
@@ -1,25 +1,26 @@
 import { Observable, Subscriber } from 'rxjs';
 import { DocumentReference, Query, Action, Reference, DocumentSnapshot, QuerySnapshot } from '../interfaces';
 import { map, share } from 'rxjs/operators';
+import { firestore } from 'firebase';
 
-function _fromRef<T, R>(ref: Reference<T>): Observable<R> {
+function _fromRef<T, R>(ref: any, options?: firestore.SnapshotListenOptions): Observable<R> {
   return new Observable(subscriber => {
-    const unsubscribe = ref.onSnapshot(subscriber);
+    const unsubscribe = ref.onSnapshot(options || {}, ref as any)
     return { unsubscribe };
   });
 }
 
-export function fromRef<R>(ref: DocumentReference | Query) {
-  return _fromRef<typeof ref, R>(ref).pipe(share());
+export function fromRef<R>(ref: any, options?: firestore.SnapshotListenOptions) {
+  return _fromRef<typeof ref, R>(ref, options).pipe(share());
 }
 
-export function fromDocRef<T>(ref: DocumentReference): Observable<Action<DocumentSnapshot<T>>>{
-  return fromRef<DocumentSnapshot<T>>(ref)
+export function fromDocRef<T>(ref: any, options?: firestore.SnapshotListenOptions): Observable<Action<DocumentSnapshot<T>>>{
+  return fromRef<DocumentSnapshot<T>>(options, ref)
     .pipe(
       map(payload => ({ payload, type: 'value' }))
     );
 }
 
-export function fromCollectionRef<T>(ref: Query): Observable<Action<QuerySnapshot<T>>> {
-  return fromRef<QuerySnapshot<T>>(ref).pipe(map(payload => ({ payload, type: 'query' })));
+export function fromCollectionRef<T>(ref: Query, options?: firestore.SnapshotListenOptions,): Observable<Action<QuerySnapshot<T>>> {
+  return fromRef<QuerySnapshot<T>>(ref, options).pipe(map(payload => ({ payload, type: 'query' })));
 }

--- a/src/firestore/observable/fromRef.ts
+++ b/src/firestore/observable/fromRef.ts
@@ -3,9 +3,9 @@ import { DocumentReference, Query, Action, Reference, DocumentSnapshot, QuerySna
 import { map, share } from 'rxjs/operators';
 import { firestore } from 'firebase';
 
-function _fromRef<T, R>(ref: any, options?: firestore.SnapshotListenOptions): Observable<R> {
+function _fromRef<T, R>(ref: Query, options?: firestore.SnapshotListenOptions): Observable<R> {
   return new Observable(subscriber => {
-    const unsubscribe = ref.onSnapshot(options || {}, ref as any)
+    const unsubscribe = ref.onSnapshot(options || {}, subscriber as any)
     return { unsubscribe };
   });
 }
@@ -14,11 +14,11 @@ export function fromRef<R>(ref: any, options?: firestore.SnapshotListenOptions) 
   return _fromRef<typeof ref, R>(ref, options).pipe(share());
 }
 
-export function fromDocRef<T>(ref: any, options?: firestore.SnapshotListenOptions): Observable<Action<DocumentSnapshot<T>>>{
-  return fromRef<DocumentSnapshot<T>>(options, ref)
-    .pipe(
-      map(payload => ({ payload, type: 'value' }))
-    );
+export function fromDocRef<T>(ref: DocumentReference): Observable<DocumentSnapshot<T>>{
+  return new Observable(subscriber => {
+    const unsubscribe = ref.onSnapshot(subscriber as any)
+    return { unsubscribe };
+  });
 }
 
 export function fromCollectionRef<T>(ref: Query, options?: firestore.SnapshotListenOptions,): Observable<Action<QuerySnapshot<T>>> {


### PR DESCRIPTION
Addressing #1747.

## Add support for metadata changes via the SnapshotListenOptions

In some cases you need to listen to metadata updates to know if you want to surface an event. If you only want to display server data or know when something offline has been modified.

```ts
constructor(afs: AngularFirestore) {
  const items$ = afs.collection('items').snapshotChanges({ includeMetadataChanges: true });
  // or you can specify events
  const addedItems$ = afs.collection('items').snapshotChanges(['added'], { includeMetadataChanges: true });
}
```