### PR TITLE
feat(fcm): Lazy messaging, for compatibility with SSR

### DIFF
--- a/src/core/angularfire2.ts
+++ b/src/core/angularfire2.ts
@@ -36,3 +36,15 @@ export class FirebaseZoneScheduler {
     });
   }
 }
+
+export const runOutsideAngular = (zone: NgZone) => <T>(obs$: Observable<T>): Observable<T> => {
+  return new Observable<T>(subscriber => {
+    return zone.runOutsideAngular(() => {
+      return obs$.subscribe(
+        value => zone.run(() => subscriber.next(value)),
+        error => zone.run(() => subscriber.error(error)),
+        ()    => zone.run(() => subscriber.complete()),
+      );
+    });
+  });
+}

--- a/src/messaging/messaging.module.ts
+++ b/src/messaging/messaging.module.ts
@@ -1,7 +1,5 @@
 import { NgModule } from '@angular/core';
-import { AngularFireModule, FirebaseApp } from 'angularfire2';
 import { AngularFireMessaging } from './messaging';
-import 'firebase/messaging';
 
 @NgModule({
   providers: [ AngularFireMessaging ]

--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -1,15 +1,14 @@
 import { Injectable, Inject, Optional, NgZone, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { messaging } from 'firebase';
-import { requestPermission } from './observable/request-permission';
 import { Observable, empty, from, of, throwError } from 'rxjs';
-import { mergeMap, catchError } from 'rxjs/operators';
-import { FirebaseOptions, FirebaseAppConfig } from 'angularfire2';
+import { mergeMap, catchError, map, switchMap, concat, defaultIfEmpty } from 'rxjs/operators';
+import { FirebaseOptions, FirebaseAppConfig, runOutsideAngular } from 'angularfire2';
 import { FirebaseOptionsToken, FirebaseNameOrConfigToken, _firebaseAppFactory, FirebaseZoneScheduler } from 'angularfire2';
 
 @Injectable()
 export class AngularFireMessaging {
-  messaging: messaging.Messaging;
+  messaging: Observable<messaging.Messaging>;
   requestPermission: Observable<void>;
   getToken: Observable<string|null>;
   tokenChanges: Observable<string|null>;
@@ -23,52 +22,58 @@ export class AngularFireMessaging {
     @Inject(PLATFORM_ID) platformId: Object,
     zone: NgZone
   ) {
-    const scheduler = new FirebaseZoneScheduler(zone, platformId);
-    this.messaging = zone.runOutsideAngular(() => {
-      const app = _firebaseAppFactory(options, nameOrConfig);
-      return app.messaging();
-    });
 
     if (isPlatformBrowser(platformId)) {
 
-      this.requestPermission = scheduler.runOutsideAngular(
-        requestPermission(this.messaging)
+      const requireMessaging = from(require('firebase/messaging'));
+
+      this.messaging = requireMessaging.pipe(
+        map(() => _firebaseAppFactory(options, nameOrConfig)),
+        map(app => app.messaging()),
+        runOutsideAngular(zone)
       );
 
-      this.getToken = scheduler.runOutsideAngular(
-        from(this.messaging.getToken())
-      );
-
-      this.tokenChanges = scheduler.runOutsideAngular(
-        new Observable(subscriber => {
-          this.messaging.getToken().then(t => subscriber.next(t));
-          this.messaging.onTokenRefresh(subscriber.next);
-        })
-      );
-
-      this.messages = scheduler.runOutsideAngular(
-        new Observable(subscriber => {
-          this.messaging.onMessage(subscriber.next);
-        })
-      );
-
-      this.requestToken = this.requestPermission.pipe(
-        catchError(() => of(null)),
-        mergeMap(() => this.tokenChanges),
+      this.requestPermission = this.messaging.pipe(
+        switchMap(messaging => messaging.requestPermission()),
+        runOutsideAngular(zone)
       );
 
     } else {
 
+      this.messaging = empty();
       this.requestPermission = throwError('Not available on server platform.');
-      this.getToken = of(null);
-      this.tokenChanges = of(null);
-      this.messages = empty();
-      this.requestToken = of(null);
 
     }
 
-    this.deleteToken = (token: string) => scheduler.runOutsideAngular(
-      from(this.messaging.deleteToken(token))
+    this.getToken = this.messaging.pipe(
+      switchMap(messaging => messaging.getToken()),
+      defaultIfEmpty(null),
+      runOutsideAngular(zone)
+    );
+
+    const tokenChanges = this.messaging.pipe(
+      switchMap(messaging => new Observable(messaging.onTokenRefresh)),
+      runOutsideAngular(zone)
+    );
+
+    this.tokenChanges = this.getToken.pipe(
+      concat(tokenChanges)
+    );
+
+    this.messages = this.messaging.pipe(
+      switchMap(messaging => new Observable(messaging.onMessage)),
+      runOutsideAngular(zone)
+    );
+
+    this.requestToken = this.requestPermission.pipe(
+      catchError(() => of(null)),
+      mergeMap(() => this.tokenChanges)
+    );
+
+    this.deleteToken = (token: string) => this.messaging.pipe(
+      switchMap(messaging => messaging.deleteToken(token)),
+      defaultIfEmpty(false),
+      runOutsideAngular(zone)
     );
   }
 

--- a/src/messaging/observable/request-permission.ts
+++ b/src/messaging/observable/request-permission.ts
@@ -1,6 +1,0 @@
-import { Observable, from } from 'rxjs';
-import { messaging } from 'firebase';
-
-export function requestPermission(messaging: messaging.Messaging): Observable<void> {
-  return from(messaging.requestPermission()!);
-}

--- a/src/messaging/public_api.ts
+++ b/src/messaging/public_api.ts
@@ -1,3 +1,2 @@
-export * from './observable/request-permission';
 export * from './messaging';
 export * from './messaging.module';


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

FCM is not able to be included in node, it fails with a `self not defined` error. Rather than track this down and fix upstream, since FCM doesn't make sense server-side, let's jump the gun here and make the MessagingModule lazy.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

