### PR TITLE
fixing error TS7006: Parameter 'string' implicitly has an 'any' type.…

### DIFF
--- a/src/messaging/messaging.ts
+++ b/src/messaging/messaging.ts
@@ -14,7 +14,7 @@ export class AngularFireMessaging {
   tokenChanges: Observable<string|null>;
   messages: Observable<{}>;
   requestToken: Observable<string|null>;
-  deleteToken: (string) => Observable<boolean>;
+  deleteToken: (token: string) => Observable<boolean>;
 
   constructor(
     @Inject(FirebaseOptionsToken) options:FirebaseOptions,


### PR DESCRIPTION
… in messaging.ts

string is compiled as function param name instead of type.

