### PR TITLE
fix(functions): Set default functions region and add documentation - fix #1945

### DIFF
--- a/docs/functions/functions.md
+++ b/docs/functions/functions.md
@@ -26,6 +26,29 @@ import { environment } from '../environments/environment';
 export class AppModule {}
 ```
 
+### Configure the Function region with the FunctionsRegionToken Injection Token
+
+Allow configuration of Function region with the `FunctionsRegionToken` Injection Token by adding it to the `providers` section of your `NgModule`. The default is `us-central1`.
+
+```ts
+import { NgModule } from '@angular/core';
+import { AngularFireFunctionsModule, FunctionsRegionToken } from '@angular/fire/functions';
+
+@NgModule({
+  imports: [
+    ...
+    AngularFireFunctionsModule,
+    ...
+  ],
+  ...
+  providers: [
+   { provide: FunctionsRegionToken, useValue: 'asia-northeast1' }
+  ]
+})
+export class AppModule {}
+
+```
+
 ### Injecting the AngularFireFunctions service
 
 Once the `AngularFireFunctionsModule` is registered you can inject the `AngularFireFunctions` service.
@@ -47,8 +70,8 @@ export class AppComponent {
 
 AngularFireFunctions is super easy. You create a function on the server side and then "call" it by its name with the client library. 
 
-| method   |                    |
-| ---------|--------------------|
+| method                                   |                                                                                                                           |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `httpCallable(name: string): (data: T) ` | Creates a callable function based on a function name. Returns a function that can create the observable of the http call. |
 ```ts
 

--- a/docs/functions/functions.md
+++ b/docs/functions/functions.md
@@ -70,8 +70,8 @@ export class AppComponent {
 
 AngularFireFunctions is super easy. You create a function on the server side and then "call" it by its name with the client library. 
 
-| method                                   |                                                                                                                           |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| method   |                    |
+| ---------|--------------------|
 | `httpCallable(name: string): (data: T) ` | Creates a callable function based on a function name. Returns a function that can create the observable of the http call. |
 ```ts
 

--- a/src/functions/functions.ts
+++ b/src/functions/functions.ts
@@ -5,6 +5,7 @@ import { FirebaseOptions, FirebaseAppConfig } from '@angular/fire';
 import { FirebaseFunctions, FirebaseOptionsToken, FirebaseNameOrConfigToken, _firebaseAppFactory, FirebaseZoneScheduler } from '@angular/fire';
 
 export const FunctionsRegionToken = new InjectionToken<string>('angularfire2.functions.region');
+export const FunctionsDefaultRegion = 'us-central1';
 
 @Injectable()
 export class AngularFireFunctions {
@@ -27,7 +28,7 @@ export class AngularFireFunctions {
     
     this.functions = zone.runOutsideAngular(() => {
       const app = _firebaseAppFactory(options, nameOrConfig);
-      return app.functions(region);
+      return app.functions(region || FunctionsDefaultRegion);
     });
 
   }


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #1945
   - Docs included?: No
   - Test units included?: No
   - In a clean directory, `yarn install`, `yarn test` run successfully? Yes

### Description

Added a FunctionsDefaultRegion, so the user does not need to add a FunctionsRegionToken to his ngModule.

I also edited the documentation to use the FunctionsRegionToken.

IMPORTANT: I added `FunctionsDefaultRegion` as constant directly int the functions.ts . If you manage those constants anywhere also or inside the class, please change it!
