### PR TITLE
Add StorageBucket injection token to storage docs

### DIFF
--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -26,6 +26,20 @@ import { environment } from '../environments/environment';
 export class AppModule {}
 ```
 
+The `StorageBucket` injection token can be used to customise the storage bucket.
+
+```ts
+import {AngularFireStorageModule, StorageBucket} from '@angular/fire/storage';
+
+@NgModule({
+  providers: [
+    { provide: StorageBucket, useValue: 'my-bucket-name' }
+  ],
+  ...
+})
+export class AppModule {}
+```
+
 ### Injecting the AngularFireStorage service
 
 Once the `AngularFireStorageModule` is registered you can inject the `AngularFireStorage` service.


### PR DESCRIPTION
### Checklist

   - Issue number for this PR: #1875
   - Docs included?: Only changed docs
   - Test units included?: No, just change to docs
   - In a clean directory, `yarn install`, `yarn test` run successfully? Yes

### Description

Added short `StorageBucket` example to storage docs.
