### PR TITLE
feat(config): remove redundant setting

### DIFF
--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -18,8 +18,6 @@ export const EnablePersistenceToken = new InjectionToken<boolean>('angularfire2.
 export const PersistenceSettingsToken = new InjectionToken<PersistenceSettings|undefined>('angularfire2.firestore.persistenceSettings');
 export const FirestoreSettingsToken = new InjectionToken<Settings>('angularfire2.firestore.settings');
 
-export const DefaultFirestoreSettings = {timestampsInSnapshots: true} as Settings;
-
 /**
  * A utility methods for associating a collection reference with
  * a query.
@@ -118,7 +116,7 @@ export class AngularFirestore {
     this.firestore = zone.runOutsideAngular(() => {
       const app = _firebaseAppFactory(options, nameOrConfig);
       const firestore = app.firestore();
-      firestore.settings(settings || DefaultFirestoreSettings);
+      firestore.settings(settings);
       return firestore;
     });
 


### PR DESCRIPTION
timestampsInSnapshots is now defaulted to true and so isn't needed to be explicitly set

### Checklist

   - Issue number for this PR: #1993 
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? no, something related to dependency install is broken

### Description

Removing a redundant setting now that this is defaulted to true in the firebase sdk.

