### PR TITLE
fix(afs): fix collection add return type

### DIFF
--- a/docs/firestore/collections.md
+++ b/docs/firestore/collections.md
@@ -312,7 +312,7 @@ For example, a user updates the third item in a list. In a state based method li
 
 ## Adding documents to a collection
 
-To add a new document to a collection with a generated id use the `add()` method. This method uses the type provided by the generic class to validate it's type structure.
+To add a new document to a collection with a generated id use the `add()` method. This method uses the type provided by the generic class to validate it's type structure.  This method returns an `AngularFirestoreDocument`, which provides methods for streaming, updating, and deleting. [See Using Documents with AngularFirestore for more information on how to use documents](documents.md).
 
 #### Basic example
 

--- a/src/firestore/collection/collection.ts
+++ b/src/firestore/collection/collection.ts
@@ -114,8 +114,8 @@ export class AngularFirestoreCollection<T=DocumentData> {
   }
 
   /**
-   * Retrieve the results of the query once. 
-   * @param options 
+   * Retrieve the results of the query once.
+   * @param options
    */
   get(options?: firestore.GetOptions) {
     return from(this.query.get(options)).pipe(
@@ -130,8 +130,8 @@ export class AngularFirestoreCollection<T=DocumentData> {
    * when you update data it is not updating data to the window of your query unless
    * the data fits the criteria of the query.
    */
-  add(data: T): Promise<DocumentReference> {
-    return this.ref.add(data);
+  add(data: T): Promise<AngularFirestoreDocument<T>> {
+    return this.ref.add(data).then(doc => new AngularFirestoreDocument<T>(doc, this.afs));
   }
 
   /**


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2000
   - Docs included?: yes
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

The method `AngularFirestoreCollection.add` is not consistent with `AngularFirestoreCollection.doc` and returns a class of type `Promise<firebase.firestore.DocumentReference>` instead of a `Promise<AngularFirestoreDocument<T>>`.

This is a breaking change of a previously undocumented behaviour.

### Code sample

This
```ts
const newDoc = this.afStore.doc<A>(await this.afStore.collection<A>('drafts').add({...}));
```
becomes
```ts
const newDoc = await this.afStore.collection<A>('drafts').add({...});
```

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

