### PR TITLE
Get rid of timestampsInSnapshots : true (error)

### DIFF
--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -18,7 +18,7 @@ export const EnablePersistenceToken = new InjectionToken<boolean>('angularfire2.
 export const PersistenceSettingsToken = new InjectionToken<PersistenceSettings|undefined>('angularfire2.firestore.persistenceSettings');
 export const FirestoreSettingsToken = new InjectionToken<Settings>('angularfire2.firestore.settings');
 
-export const DefaultFirestoreSettings = {timestampsInSnapshots: true} as Settings;
+export const DefaultFirestoreSettings = {} as Settings;
 
 /**
  * A utility methods for associating a collection reference with


### PR DESCRIPTION
@firebase/firestore: Firestore (5.8.1): 
  The timestampsInSnapshots setting now defaults to true and you no
  longer need to explicitly set it. In a future release, the setting
  will be removed entirely and so it is recommended that you remove it
  from your firestore.settings() call now.

Remove the timestampsInSnapshots : true, because now it is default to true.
If I did something wrong :) please correct me! :)

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #nnn (required)
   - Docs included?: (yes/no; required for all API/functional changes) 
   - Test units included?: (yes/no; required) 
   - In a clean directory, `yarn install`, `yarn test` run successfully? (yes/no; required)

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

