### PR TITLE
fix: change firestore default settings version comparison

### DIFF
--- a/src/firestore/firestore.ts
+++ b/src/firestore/firestore.ts
@@ -19,7 +19,9 @@ export const PersistenceSettingsToken = new InjectionToken<PersistenceSettings|u
 export const FirestoreSettingsToken = new InjectionToken<Settings>('angularfire2.firestore.settings');
 
 // timestampsInSnapshots was depreciated in 5.8.0
-export const DefaultFirestoreSettings = (parseFloat(SDK_VERSION) < 5.8 ? {timestampsInSnapshots: true} : {}) as Settings;
+const major = parseInt(SDK_VERSION.split('.')[0]);
+const minor = parseInt(SDK_VERSION.split('.')[1]);
+export const DefaultFirestoreSettings = ((major < 5 || (major == 5 && minor < 8)) ? {timestampsInSnapshots: true} : {}) as Settings;
 
 /**
  * A utility methods for associating a collection reference with


### PR DESCRIPTION
Change the condition that determines whether timestampsInSnapshots setting is set to true.
This is done to order to comply with multiple digits minor versions of firebase sdk.
For example: version 5.10.0 is greater than 5.8.0

fixes #2050

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2050 
   - Docs included?: no
   - Test units included?: no
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #2050 
Change the condition that determines whether timestampsInSnapshots setting is set to true.
This is done to order to comply with multiple digits minor versions of firebase sdk.
For example: version 5.10.0 is greater than 5.8.0
