### PR TITLE
chore(): Travis should use Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- 'node'
+- 'lts/*'
 
 addons:
   chrome: stable


### PR DESCRIPTION
**Node 12 has been cut, but we're not compatible yet.** Fall to `lts/*` (10.15, something or other?) to fix Travis builds.