### PR TITLE
chore(): removing the new peers, unneeded and confusing to existing users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="5.2.1"></a>
+# [5.2.1](https://github.com/angular/angularfire2/compare/5.2.0...5.2.1) (2019-06-01)
+
+Removed unnecessary `peerDependencies` ([#2095](https://github.com/angular/angularfire2/pull/2095)) ([5e49442](https://github.com/angular/angularfire2/pull/2095/commits/5e49442))
+
 <a name="5.2.0"></a>
 # [5.2.0](https://github.com/angular/angularfire2/compare/5.1.3...5.2.0) (2019-05-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 Removed unnecessary `peerDependencies` ([#2095](https://github.com/angular/angularfire2/pull/2095)) ([5e49442](https://github.com/angular/angularfire2/pull/2095/commits/5e49442))
 
 <a name="5.2.0"></a>
-# [5.2.0](https://github.com/angular/angularfire2/compare/5.1.3...5.2.0) (2019-05-24)
+# [5.2.0](https://github.com/angular/angularfire2/compare/5.1.3...5.2.0) (2019-05-31)
 
 AngularFire 5.2 introduces support for Angular 8 and version 6 of the Firebase SDK.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/fire",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "The official library of Firebase and Angular.",
   "private": true,
   "scripts": {

--- a/src/core/package.json
+++ b/src/core/package.json
@@ -21,18 +21,11 @@
   "author": "angular,firebase",
   "license": "MIT",
   "peerDependencies": {
-    "@angular-devkit/architect": "ANGULAR_DEVKIT_ARCH_VERSION",
-    "@angular-devkit/core": "ANGULAR_VERSION",
-    "@angular-devkit/schematics": "ANGULAR_VERSION",
     "@angular/common": "ANGULAR_VERSION",
     "@angular/core": "ANGULAR_VERSION",
     "@angular/platform-browser": "ANGULAR_VERSION",
     "@angular/platform-browser-dynamic": "ANGULAR_VERSION",
     "firebase": "FIREBASE_VERSION",
-    "firebase-tools": "FIREBASE_TOOLS_VERSION",
-    "fuzzy": "FUZZY_VERSION",
-    "inquirer": "INQUIRER_VERSION",
-    "inquirer-autocomplete-prompt": "INQUIRER_AUTOCOMPLETE_VERSION",
     "rxjs": "RXJS_VERSION"
   },
   "typings": "index.d.ts",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Checklist

   - Issue number for this PR: #2094
   - Docs included?: not needed
   - Test units included?: covered by existing
   - In a clean directory, `yarn install`, `yarn test` run successfully? yes

### Description

The new peerDependencies included for the schematics aren't necessary to include in the published package and the peer warnings are confusing, especially for yarn users.

The dependencies on `fuzzy`, `inquirer`, and the `@angular-devkit/*` are taken care of if the developer uses `ng add @angular/fire` (4ed421c) and are only used in that step.

The `firebase-tools` dependency doesn't have to be expressed as a peer, as if you try to do `ng deploy` without `firebase-tools` installed you get a good error:

```
Error when trying to deploy: 
Cannot find module 'firebase-tools'
```

