### PR TITLE
Fix list update typing on list to enable partial updates

### DIFF
--- a/src/database/interfaces.ts
+++ b/src/database/interfaces.ts
@@ -9,7 +9,7 @@ export interface AngularFireList<T> {
   snapshotChanges(events?: ChildEvent[]): Observable<SnapshotAction<T>[]>;
   stateChanges(events?: ChildEvent[]): Observable<SnapshotAction<T>>;
   auditTrail(events?: ChildEvent[]): Observable<SnapshotAction<T>[]>;
-  update(item: FirebaseOperation, data: T): Promise<void>;
+  update(item: FirebaseOperation, data: Partial<T>): Promise<void>;
   set(item: FirebaseOperation, data: T): Promise<void>;
   push(data: T): database.ThenableReference;
   remove(item?: FirebaseOperation): Promise<void>;


### PR DESCRIPTION
I added `Partial` type around type parameter in update operation, to enable partial updates, as claimed in [docs](https://github.com/angular/angularfire2/blob/master/docs/rtdb/lists.md#updating-items-in-the-list-using-update)

